### PR TITLE
Toggle calling of Update_RCONST, Update_PHOTO, Update_SUN within integrators -- Closes #9

### DIFF
--- a/.ci-pipelines/ci-manual-cleanup-script.sh
+++ b/.ci-pipelines/ci-manual-cleanup-script.sh
@@ -18,7 +18,10 @@ for this_test in $all_tests; do
     echo ""
     echo ">>>>>>>> Making clean for $this_test <<<<<<<<"
     echo ""
-    make -f Makefile_$this_test clean
+    make -f Makefile_$this_test distclean
+
+    # Also remove other output files from the tests
+    rm -f *.m
 
     cd ..
 

--- a/ci-tests/radau90/general.f90
+++ b/ci-tests/radau90/general.f90
@@ -1,0 +1,1 @@
+../../drv/general.f90

--- a/ci-tests/rk/general.f90
+++ b/ci-tests/rk/general.f90
@@ -1,0 +1,1 @@
+../../drv/general.f90

--- a/ci-tests/sd/general.f90
+++ b/ci-tests/sd/general.f90
@@ -1,0 +1,1 @@
+../drv/general.f90

--- a/ci-tests/sdadj/general_adj.f90
+++ b/ci-tests/sdadj/general_adj.f90
@@ -1,0 +1,1 @@
+../../drv/general_adj.f90

--- a/int/kpp_dvode.f90
+++ b/int/kpp_dvode.f90
@@ -297,8 +297,8 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
    !            =  4 ! Call Update_SUN from within the integrator
    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-   !            =  6 ! Not implemented
-   !            =  7 ! Not implemented
+   !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+   !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
    CALL Integrator_Update_Options( ICNTRL(15),          &
                                    Do_Update_RCONST,    &
                                    Do_Update_PHOTO,     &

--- a/int/kpp_dvode.f90
+++ b/int/kpp_dvode.f90
@@ -11,6 +11,13 @@ MODULE KPP_ROOT_Integrator
   PUBLIC
   SAVE
   
+!~~~> Flags to determine if we should call the UPDATE_* routines from within 
+!~~~> the integrator.  If using KPP in an external model, you might want to
+!~~~> disable these calls (via ICNTRL(15)) to avoid excess computations.
+  LOGICAL :: Do_Update_RCONST
+  LOGICAL :: Do_Update_PHOTO
+  LOGICAL :: Do_Update_SUN
+
   !~~~>  Statistics on the work performed by the VODE method
   INTEGER :: Nfun,Njac,Nstp,Nacc,Nrej,Ndec,Nsol,Nsng
   INTEGER, PARAMETER :: ifun=1, ijac=2, istp=3, iacc=4,  &
@@ -245,6 +252,8 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
 
    USE KPP_ROOT_Parameters
    USE KPP_ROOT_Global
+   USE KPP_ROOT_Util, ONLY : Integrator_Update_Options
+  
    IMPLICIT NONE
 
    KPP_REAL, INTENT(IN) :: TIN  ! Start Time
@@ -278,14 +287,31 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
      WHERE(RCNTRL_U(:) > 0) RCNTRL(:) = RCNTRL_U(:)
    END IF
 
+   ! Determine the settings of the Do_Update_* flags, which determine
+   ! whether or not we need to call Update_* routines in the integrator
+   ! (or not, if we are calling them from a higher-level)
+   ! ICNTRL(15) = -1 ! Do not call Update_* functions within the integrator
+   !            =  0 ! Status quo
+   !            =  1 ! Call Update_RCONST from within the integrator
+   !            =  2 ! Call Update_PHOTO from within the integrator
+   !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
+   !            =  4 ! Call Update_SUN from within the integrator
+   !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
+   !            =  6 ! Not implemented
+   !            =  7 ! Not implemented
+   CALL Integrator_Update_Options( ICNTRL(15),          &
+                                   Do_Update_RCONST,    &
+                                   Do_Update_PHOTO,     &
+                                   Do_Update_Sun       )
 
-    OPTIONS = SET_OPTS(USER_SUPPLIED_JACOBIAN=.TRUE., SPARSE_J=.TRUE.,             &
-              ABSERR_VECTOR=ATOL, RELERR_VECTOR=RTOL, MXSTEP=100000,               &
-              NZSWAG=LU_NONZERO,   METHOD_FLAG=26,                                 &
-              MA28_ELBOW_ROOM=10, MC19_SCALING=.TRUE., MA28_MESSAGES=.FALSE.,      &
-              MA28_EPS=1.0D-4, MA28_RPS=.TRUE.,                                    &
+    OPTIONS = SET_OPTS(USER_SUPPLIED_JACOBIAN=.TRUE., SPARSE_J=.TRUE.,        &
+              ABSERR_VECTOR=ATOL, RELERR_VECTOR=RTOL, MXSTEP=100000,          &
+              NZSWAG=LU_NONZERO,   METHOD_FLAG=26,                            &
+              MA28_ELBOW_ROOM=10, MC19_SCALING=.TRUE., MA28_MESSAGES=.FALSE., &
+              MA28_EPS=1.0D-4, MA28_RPS=.TRUE.,                               &
               USER_SUPPLIED_SPARSITY=.TRUE.)
 
+   ! Call the integrator
    CALL USERSETS_IAJA(LU_IROW,LU_NONZERO,LU_ICOL,LU_NONZERO)
    ISTATE = 1
    ITASK  = 1
@@ -325,9 +351,9 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
       
 !      TOLD = TIME
 !      TIME = T
-!      CALL Update_SUN()
-!      CALL Update_RCONST()
-!      CALL Update_PHOTO()
+!      IF ( Do_Update_SUN    ) CALL Update_SUN()
+!      IF ( Do_Update_RCONST ) CALL Update_RCONST()
+!      IF ( Do_Update_PHOTO  ) CALL Update_PHOTO()
 !      TIME = TOLD
 
       CALL Fun(V, FIX, RCONST, FCT)
@@ -361,9 +387,9 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
   
 !      TOLD = TIME
 !      TIME = T
-!      CALL Update_SUN()
-!      CALL Update_RCONST()
-!      CALL Update_PHOTO()
+!      IF ( Do_Update_SUN    ) CALL Update_SUN()
+!      IF ( Do_Update_RCONST ) CALL Update_RCONST()
+!      IF ( Do_Update_PHOTO  ) CALL Update_PHOTO()
 !      TIME = TOLD
     
 #ifdef FULL_ALGEBRA    

--- a/int/kpp_lsode.f90
+++ b/int/kpp_lsode.f90
@@ -97,8 +97,8 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
    !            =  4 ! Call Update_SUN from within the integrator
    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-   !            =  6 ! Not implemented
-   !            =  7 ! Not implemented
+   !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+   !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
    CALL Integrator_Update_Options( ICNTRL(15),          &
                                    Do_Update_RCONST,    &
                                    Do_Update_PHOTO,     &
@@ -171,8 +171,8 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
 !        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
 !        =  4 :  Call Update_SUN from within the integrator
 !        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Not implemented
-!        =  7 :  Not implemented
+!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :  Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
 !
 !~~~>  Real parameters
 !

--- a/int/kpp_lsode.f90
+++ b/int/kpp_lsode.f90
@@ -13,11 +13,18 @@ MODULE KPP_ROOT_Integrator
   USE KPP_ROOT_JacobianSP, ONLY: LU_DIAG
   USE KPP_ROOT_LinearAlgebra, ONLY: KppDecomp, KppSolve, &
                Set2zero, WLAMCH
-  
+
   IMPLICIT NONE
   PUBLIC
   SAVE
   
+!~~~> Flags to determine if we should call the UPDATE_* routines from within 
+!~~~> the integrator.  If using KPP in an external model, you might want to
+!~~~> disable these calls (via ICNTRL(15)) to avoid excess computations.
+  LOGICAL :: Do_Update_RCONST
+  LOGICAL :: Do_Update_PHOTO
+  LOGICAL :: Do_Update_SUN
+
   !~~~>  Statistics on the work performed by the LSODE method
   INTEGER :: Nfun,Njac,Nstp,Nacc,Nrej,Ndec,Nsol,Nsng
   INTEGER, PARAMETER :: ifun=1, ijac=2, istp=3, iacc=4,  &
@@ -47,6 +54,8 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
 
    USE KPP_ROOT_Parameters
    USE KPP_ROOT_Global
+   USE KPP_ROOT_Util, ONLY : Integrator_Update_Options
+
    IMPLICIT NONE
 
    KPP_REAL, INTENT(IN) :: TIN  ! Start Time
@@ -78,6 +87,24 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
      WHERE(RCNTRL_U(:) > 0) RCNTRL(:) = RCNTRL_U(:)
    END IF
 
+   ! Determine the settings of the Do_Update_* flags, which determine
+   ! whether or not we need to call Update_* routines in the integrator
+   ! (or not, if we are calling them from a higher-level)
+   ! ICNTRL(15) = -1 ! Do not call Update_* functions within the integrator
+   !            =  0 ! Status quo
+   !            =  1 ! Call Update_RCONST from within the integrator
+   !            =  2 ! Call Update_PHOTO from within the integrator
+   !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
+   !            =  4 ! Call Update_SUN from within the integrator
+   !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
+   !            =  6 ! Not implemented
+   !            =  7 ! Not implemented
+   CALL Integrator_Update_Options( ICNTRL(15),          &
+                                   Do_Update_RCONST,    &
+                                   Do_Update_PHOTO,     &
+                                   Do_Update_Sun       )
+
+   ! Call the integrator
    CALL KppLsode( TIN,TOUT,VAR,RTOL,ATOL,                &
                   RCNTRL,ICNTRL,RSTATUS,ISTATUS,IERR )
 
@@ -135,6 +162,17 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
 !        For ICNTRL(4)=0 the default value of 100000 is used
 !
 !    ICNTRL(5)  -> maximum order of the integration formula allowed
+!
+!    ICNTRL(15) -> Toggles calling of Update_* functions w/in the integrator
+!        = -1 :  Do not call Update_* functions within the integrator
+!        =  0 :  Status quo
+!        =  1 :  Call Update_RCONST from within the integrator
+!        =  2 :  Call Update_PHOTO from within the integrator
+!        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
+!        =  4 :  Call Update_SUN from within the integrator
+!        =  5 :  Call Update_SUN and Update_RCONST from within the int.
+!        =  6 :  Not implemented
+!        =  7 :  Not implemented
 !
 !~~~>  Real parameters
 !
@@ -3370,9 +3408,9 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
       
 !      TOLD = TIME
 !      TIME = T
-!      CALL Update_SUN()
-!      CALL Update_RCONST()
-!      CALL Update_PHOTO()
+!      IF ( Do_Update_SUN    ) CALL Update_SUN()
+!      IF ( Do_Update_RCONST ) CALL Update_RCONST()
+!      IF ( Do_Update_PHOTO  ) CALL Update_PHOTO()
 !      TIME = TOLD
 
       CALL Fun(V, FIX, RCONST, FCT)
@@ -3405,9 +3443,9 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
   
 !      TOLD = TIME
 !      TIME = T
-!      CALL Update_SUN()
-!      CALL Update_RCONST()
-!      CALL Update_PHOTO()
+!      IF ( Do_Update_SUN    ) CALL Update_SUN()
+!      IF ( Do_Update_RCONST ) CALL Update_RCONST()
+!      IF ( Do_Update_PHOTO  ) CALL Update_PHOTO()
 !      TIME = TOLD
     
 #ifdef FULL_ALGEBRA    

--- a/int/kpp_radau5.f90
+++ b/int/kpp_radau5.f90
@@ -16,6 +16,13 @@ MODULE KPP_ROOT_Integrator
   PUBLIC
   SAVE
   
+!~~~> Flags to determine if we should call the UPDATE_* routines from within 
+!~~~> the integrator.  If using KPP in an external model, you might want to
+!~~~> disable these calls (via ICNTRL(15)) to avoid excess computations.
+  LOGICAL :: Do_Update_RCONST
+  LOGICAL :: Do_Update_PHOTO
+  LOGICAL :: Do_Update_SUN
+
   ! Statistics
   INTEGER :: Nfun, Njac, Nstp, Nacc, Nrej, Ndec, Nsol, Nsng
   
@@ -47,8 +54,9 @@ CONTAINS
   SUBROUTINE INTEGRATE( TIN, TOUT, &
     ICNTRL_U, RCNTRL_U, ISTATUS_U, RSTATUS_U, IERR_U )
 
-    USE KPP_ROOT_Parameters, ONLY: NVAR
-    USE KPP_ROOT_Global,     ONLY: ATOL,RTOL,VAR
+    USE KPP_ROOT_Parameters, ONLY : NVAR
+    USE KPP_ROOT_Global,     ONLY : ATOL,RTOL,VAR
+    USE KPP_ROOT_Util,       ONLY : Integrator_Update_Options
 
     IMPLICIT NONE
 
@@ -82,10 +90,27 @@ CONTAINS
     IF (PRESENT(ICNTRL_U)) ICNTRL(1:20) = ICNTRL_U(1:20)
     IF (PRESENT(RCNTRL_U)) RCNTRL(1:20) = RCNTRL_U(1:20)
    
+    ! Determine the settings of the Do_Update_* flags, which determine
+    ! whether or not we need to call Update_* routines in the integrator
+    ! (or not, if we are calling them from a higher-level)
+    ! ICNTRL(15) = -1 ! Do not call Update_* functions within the integrator
+    !            =  0 ! Status quo
+    !            =  1 ! Call Update_RCONST from within the integrator
+    !            =  2 ! Call Update_PHOTO from within the integrator
+    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
+    !            =  4 ! Call Update_SUN from within the integrator
+    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
+    !            =  6 ! Not implemented
+    !            =  7 ! Not implemented
+    CALL Integrator_Update_Options( ICNTRL(15),          &
+                                    Do_Update_RCONST,    &
+                                    Do_Update_PHOTO,     &
+                                    Do_Update_Sun       )
 
-    CALL RADAU5(  NVAR,TIN,TOUT,VAR,H,                  &
-                  RTOL,ATOL,                            &
-                  RCNTRL,ICNTRL,RSTATUS,ISTATUS,IERR  )
+    ! Call the integrator
+    CALL RADAU5( NVAR,TIN,TOUT,VAR,H,                  &
+                 RTOL,ATOL,                            &
+                 RCNTRL,ICNTRL,RSTATUS,ISTATUS,IERR  )
 
 !!$    Ntotal = Ntotal + Nstp
 !!$    PRINT*,'NSTEPS=',Nstp,' (',Ntotal,')'
@@ -225,6 +250,17 @@ CONTAINS
 !              for simple problems, the choice iwork(8) == 2 produces
 !              often slightly faster runs
 !              ( currently unused )
+!
+!    ICNTRL(15) -> Toggles calling of Update_* functions w/in the integrator
+!        = -1 :  Do not call Update_* functions within the integrator
+!        =  0 :  Status quo
+!        =  1 :  Call Update_RCONST from within the integrator
+!        =  2 :  Call Update_PHOTO from within the integrator
+!        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
+!        =  4 :  Call Update_SUN from within the integrator
+!        =  5 :  Call Update_SUN and Update_RCONST from within the int.
+!        =  6 :  Not implemented
+!        =  7 :  Not implemented
 !
 !~~~>  Real input parameters:
 !
@@ -478,8 +514,9 @@ CONTAINS
 
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   SUBROUTINE RAD_Integrator( N,T,Y,Tend,Hmax,H,RelTol,AbsTol,ITOL,IDID, &
-        Max_no_steps,Roundoff,FacSafe,ThetaMin,TolNewton,Qmin,Qmax,      &
+   SUBROUTINE RAD_Integrator(                                         &
+        N,T,Y,Tend,Hmax,H,RelTol,AbsTol,ITOL,IDID,                    &
+        Max_no_steps,Roundoff,FacSafe,ThetaMin,TolNewton,Qmin,Qmax,   &
         NewtonMaxit,StartNewton,Gustafsson,FacMin,FacMax,FacRej )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !     CORE INTEGRATOR FOR RADAU5
@@ -540,7 +577,7 @@ CONTAINS
       Nsng=0
 !      Told=T
       CALL RAD_ErrorScale(N,ITOL,AbsTol,RelTol,Y,SCAL)
-      CALL FUN_CHEM(T,Y,Y0)
+      CALL FUN_CHEM( T, Y, Y0 )
       
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !~~~>  Time loop begins
@@ -549,7 +586,7 @@ Tloop: DO WHILE ( (Tend-T)*Tdirection - Roundoff > ZERO )
 
       !~~~> COMPUTE JACOBIAN MATRIX ANALYTICALLY
       IF ( (.NOT.FreshJac)  .AND. (Theta > ThetaMin) ) THEN
-        CALL JAC_CHEM(T,Y,FJAC)
+        CALL JAC_CHEM( T, Y, FJAC )
         FreshJac=.TRUE.
       END IF
       
@@ -624,15 +661,15 @@ NewtonLoop:DO  NewtonIter = 1, NewtonMaxit
             DO i=1,N
                TMP(i)=Y(i)+Z1(i)
             END DO
-            CALL FUN_CHEM(T+rkC(1)*H,TMP,Z1)
+            CALL FUN_CHEM( T+rkC(1)*H, TMP, Z1 )
             DO i=1,N
                TMP(i)=Y(i)+Z2(i)
             END DO
-            CALL FUN_CHEM(T+rkC(2)*H,TMP,Z2)
+            CALL FUN_CHEM( T+rkC(2)*H, TMP, Z2 )
             DO i=1,N
                TMP(i)=Y(i)+Z3(i)
             END DO
-            CALL FUN_CHEM(T+rkC(3)*H,TMP,Z3)
+            CALL FUN_CHEM( T+rkC(3)*H, TMP, Z3 )
 
             !~~~> Solve the linear systems
             !  Z(1,2,3) = TransfInv x Z(1,2,3)
@@ -736,7 +773,7 @@ accept:IF (ERR < ONE) THEN !~~~> STEP IS ACCEPTED
             IDID=1
             RETURN
          END IF
-         CALL FUN_CHEM(T,Y,Y0)
+         CALL FUN_CHEM( T, Y, Y0 )
          Hnew=Tdirection*MIN(ABS(Hnew),HmaxN)
          Hopt=Hnew
          Hopt=MIN(H,Hnew)
@@ -1039,12 +1076,12 @@ accept:IF (ERR < ONE) THEN !~~~> STEP IS ACCEPTED
 
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   SUBROUTINE RAD_ErrorEstimate(N,FJAC,H,Y0,Y,T,&
-               E1,Z1,Z2,Z3,IP1,SCAL,ERR,        &
+   SUBROUTINE RAD_ErrorEstimate( N,FJAC,H,Y0,Y,T,      &
+               E1,Z1,Z2,Z3,IP1,SCAL,ERR,               &
                FirstStep,REJECT,GAMMA)
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       IMPLICIT NONE
-      
+
       INTEGER :: N
 #ifdef FULL_ALGEBRA      
       KPP_REAL :: FJAC(NVAR,NVAR),  E1(NVAR,NVAR)
@@ -1141,9 +1178,9 @@ firej:IF (FirstStep.OR.REJECT) THEN
 
     !Told = TIME
     !TIME = T
-    !CALL Update_SUN()
-    !CALL Update_RCONST()
-    !CALL Update_PHOTO()
+    !IF ( Do_Update_SUN    ) CALL Update_SUN()
+    !IF ( Do_Update_RCONST ) CALL Update_RCONST()
+    !IF ( Do_Update_PHOTO  ) CALL Update_PHOTO()
     !TIME = Told
     
     CALL Fun(V, FIX, RCONST, FCT)
@@ -1174,9 +1211,9 @@ firej:IF (FirstStep.OR.REJECT) THEN
 
     !Told = TIME
     !TIME = T
-    !CALL Update_SUN()
-    !CALL Update_RCONST()
-    !CALL Update_PHOTO()
+    !IF ( Do_Update_SUN    ) CALL Update_SUN()
+    !IF ( Do_Update_RCONST ) CALL Update_RCONST()
+    !IF ( Do_Update_PHOTO  ) CALL Update_PHOTO()
     !TIME = Told
     
 #ifdef FULL_ALGEBRA    

--- a/int/kpp_radau5.f90
+++ b/int/kpp_radau5.f90
@@ -100,8 +100,8 @@ CONTAINS
     !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
     !            =  4 ! Call Update_SUN from within the integrator
     !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-    !            =  6 ! Not implemented
-    !            =  7 ! Not implemented
+    !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+    !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
     CALL Integrator_Update_Options( ICNTRL(15),          &
                                     Do_Update_RCONST,    &
                                     Do_Update_PHOTO,     &
@@ -259,8 +259,8 @@ CONTAINS
 !        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
 !        =  4 :  Call Update_SUN from within the integrator
 !        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Not implemented
-!        =  7 :  Not implemented
+!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :  Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
 !
 !~~~>  Real input parameters:
 !

--- a/int/kpp_sdirk4.f90
+++ b/int/kpp_sdirk4.f90
@@ -14,10 +14,17 @@ MODULE KPP_ROOT_Integrator
   USE KPP_ROOT_JacobianSP, ONLY: LU_DIAG
   USE KPP_ROOT_LinearAlgebra, ONLY: KppDecomp, KppSolve, &
                Set2zero, WLAMCH, WAXPY, WCOPY
-  
+
   IMPLICIT NONE
   PUBLIC
   SAVE
+
+!~~~> Flags to determine if we should call the UPDATE_* routines from within 
+!~~~> the integrator.  If using KPP in an external model, you might want to
+!~~~> disable these calls (via ICNTRL(15)) to avoid excess computations.
+  LOGICAL :: Do_Update_RCONST
+  LOGICAL :: Do_Update_PHOTO
+  LOGICAL :: Do_Update_SUN
   
   !~~~>  Statistics on the work performed by the SDIRK method
   INTEGER :: Nfun,Njac,Nstp,Nacc,Nrej,Ndec,Nsol,Nsng
@@ -47,6 +54,8 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
 
    USE KPP_ROOT_Parameters
    USE KPP_ROOT_Global
+   USE KPP_ROOT_Util, ONLY : Integrator_Update_Options
+ 
    IMPLICIT NONE
 
    KPP_REAL, INTENT(IN) :: TIN  ! Start Time
@@ -75,6 +84,24 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
      WHERE(RCNTRL_U(:) > 0) RCNTRL(:) = RCNTRL_U(:)
    END IF
 
+   ! Determine the settings of the Do_Update_* flags, which determine
+   ! whether or not we need to call Update_* routines in the integrator
+   ! (or not, if we are calling them from a higher-level)
+   ! ICNTRL(15) = -1 ! Do not call Update_* functions within the integrator
+   !            =  0 ! Status quo
+   !            =  1 ! Call Update_RCONST from within the integrator
+   !            =  2 ! Call Update_PHOTO from within the integrator
+   !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
+   !            =  4 ! Call Update_SUN from within the integrator
+   !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
+   !            =  6 ! Not implemented
+   !            =  7 ! Not implemented
+   CALL Integrator_Update_Options( ICNTRL(15),          &
+                                   Do_Update_RCONST,    &
+                                   Do_Update_PHOTO,     &
+                                   Do_Update_Sun       )
+
+   ! Call the integrator
    CALL SDIRK( NVAR,TIN,TOUT,VAR,RTOL,ATOL,          &
                RCNTRL,ICNTRL,RSTATUS,ISTATUS,IERR )
 
@@ -166,6 +193,17 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
 !    ICNTRL(6)  -> starting values of Newton iterations:
 !        ICNTRL(6)=0 : starting values are interpolated (the default)
 !        ICNTRL(6)=1 : starting values are zero
+!
+!    ICNTRL(15) -> Toggles calling of Update_* functions w/in the integrator
+!        = -1 :  Do not call Update_* functions within the integrator
+!        =  0 :  Status quo
+!        =  1 :  Call Update_RCONST from within the integrator
+!        =  2 :  Call Update_PHOTO from within the integrator
+!        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
+!        =  4 :  Call Update_SUN from within the integrator
+!        =  5 :  Call Update_SUN and Update_RCONST from within the int.
+!        =  6 :  Not implemented
+!        =  7 :  Not implemented
 !
 !~~~>  Real parameters
 !
@@ -916,8 +954,8 @@ Hloop: DO WHILE (ISING /= 0)
       
       Told = TIME
       TIME = T
-      CALL Update_SUN()
-      CALL Update_RCONST()
+      IF ( Do_Update_SUN    ) CALL Update_SUN()
+      IF ( Do_Update_RCONST ) CALL Update_RCONST()
       
       CALL Fun( Y,  FIX, RCONST, P )
       
@@ -948,8 +986,8 @@ Hloop: DO WHILE (ISING /= 0)
  
       Told = TIME
       TIME = T
-      CALL Update_SUN()
-      CALL Update_RCONST()
+      IF ( Do_Update_SUN    ) CALL Update_SUN()
+      IF ( Do_Update_RCONST ) CALL Update_RCONST()
 
 #ifdef FULL_ALGEBRA
       CALL Jac_SP(Y, FIX, RCONST, JS)

--- a/int/kpp_sdirk4.f90
+++ b/int/kpp_sdirk4.f90
@@ -94,8 +94,8 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
    !            =  4 ! Call Update_SUN from within the integrator
    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-   !            =  6 ! Not implemented
-   !            =  7 ! Not implemented
+   !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+   !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
    CALL Integrator_Update_Options( ICNTRL(15),          &
                                    Do_Update_RCONST,    &
                                    Do_Update_PHOTO,     &
@@ -202,8 +202,8 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
 !        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
 !        =  4 :  Call Update_SUN from within the integrator
 !        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Not implemented
-!        =  7 :  Not implemented
+!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :  Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
 !
 !~~~>  Real parameters
 !

--- a/int/kpp_seulex.f90
+++ b/int/kpp_seulex.f90
@@ -93,8 +93,8 @@ CONTAINS
    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
    !            =  4 ! Call Update_SUN from within the integrator
    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-   !            =  6 ! Not implemented
-   !            =  7 ! Not implemented
+   !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+   !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
    CALL Integrator_Update_Options( ICNTRL(15),          &
                                    Do_Update_RCONST,    &
                                    Do_Update_PHOTO,     &
@@ -273,8 +273,8 @@ CONTAINS
 !        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
 !        =  4 :  Call Update_SUN from within the integrator
 !        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Not implemented
-!        =  7 :  Not implemented
+!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :  Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
 !
 !    ICNTRL(21),...,ICNTRL(NRDENS+20) INDICATE THE COMPONENTS, FOR WHICH
 !              DENSE OUTPUT IS REQUIRED

--- a/int/rosenbrock.f90
+++ b/int/rosenbrock.f90
@@ -87,8 +87,8 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
    !            =  4 ! Call Update_SUN from within the integrator
    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-   !            =  6 ! Not implemented
-   !            =  7 ! Not implemented
+   !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+   !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
    CALL Integrator_Update_Options( ICNTRL(15),          &
                                    Do_Update_RCONST,    &
                                    Do_Update_PHOTO,     &
@@ -194,8 +194,8 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
 !        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
 !        =  4 :  Call Update_SUN from within the integrator
 !        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Not implemented
-!        =  7 :  Not implemented
+!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :  Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
 !
 !    RCNTRL(1)  -> Hmin, lower bound for the integration step size
 !          It is strongly recommended to keep Hmin = ZERO

--- a/int/rosenbrock.f90
+++ b/int/rosenbrock.f90
@@ -22,7 +22,7 @@ MODULE KPP_ROOT_Integrator
   IMPLICIT NONE
   PUBLIC
   SAVE
-  
+
 !~~~>  Statistics on the work performed by the Rosenbrock method
   INTEGER, PARAMETER :: Nfun=1, Njac=2, Nstp=3, Nacc=4, &
                         Nrej=5, Ndec=6, Nsol=7, Nsng=8, &
@@ -58,8 +58,8 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
    ICNTRL(1) = 0        ! 0 - non-autonomous, 1 - autonomous
    ICNTRL(2) = 0        ! 0 - vector tolerances, 1 - scalars
 
-   ! If optional parameters are given, and if they are >0, 
-   ! then they overwrite default settings. 
+   ! If optional parameters are given, and if they are >0,
+   ! then they overwrite default settings.
    IF (PRESENT(ICNTRL_U)) THEN
      WHERE(ICNTRL_U(:) > 0) ICNTRL(:) = ICNTRL_U(:)
    END IF
@@ -77,7 +77,7 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
    ! PRINT*,'NSTEPS=',ISTATUS(Nstp),' (',Ntotal,')','  O3=', VAR(ind_O3)
 
    STEPMIN = RSTATUS(Nhexit)
-   ! if optional parameters are given for output they 
+   ! if optional parameters are given for output they
    ! are updated with the return information
    IF (PRESENT(ISTATUS_U)) ISTATUS_U(:) = ISTATUS(:)
    IF (PRESENT(RSTATUS_U)) RSTATUS_U(:) = RSTATUS(:)
@@ -109,7 +109,7 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
 !    (C)  Adrian Sandu, August 2004
 !    Virginia Polytechnic Institute and State University
 !    Contact: sandu@cs.vt.edu
-!    Revised by Philipp Miehe and Adrian Sandu, May 2006                  
+!    Revised by Philipp Miehe and Adrian Sandu, May 2006
 !    This implementation is part of KPP - the Kinetic PreProcessor
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !
@@ -159,6 +159,12 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
 !    ICNTRL(4)  -> maximum number of integration steps
 !        For ICNTRL(4)=0) the default value of 100000 is used
 !
+!    ICNTRL(15) -> Determine whether to update rates within the solver step
+!        ICNTRL(15)=0 : Do not update rates within the solver step
+!        ICNTRL(15)=1 : Call Update_RCONST within solver step
+!        ICNTRL(15)=2 : Call Update_RCONST & Update_PHOTO w/in solver step
+!        ICNTRL(15)=3 : Call Update_SUN & Update_RCONST w/in solver step
+!
 !    RCNTRL(1)  -> Hmin, lower bound for the integration step size
 !          It is strongly recommended to keep Hmin = ZERO
 !    RCNTRL(2)  -> Hmax, upper bound for the integration step size
@@ -198,7 +204,7 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
 !                     computed Y upon return
 !    RSTATUS(2)  -> Hexit, last accepted step before exit
 !    RSTATUS(3)  -> Hnew, last predicted step (not yet taken)
-!                   For multiple restarts, use Hnew as Hstart 
+!                   For multiple restarts, use Hnew as Hstart
 !                     in the subsequent run
 !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -266,7 +272,7 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
      CASE (6)
        CALL Rang3
      CASE DEFAULT
-       PRINT * , 'Unknown Rosenbrock method: ICNTRL(3)=',ICNTRL(3) 
+       PRINT * , 'Unknown Rosenbrock method: ICNTRL(3)=',ICNTRL(3)
        CALL ros_ErrorMsg(-2,Tstart,ZERO,IERR)
        RETURN
    END SELECT
@@ -367,66 +373,66 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
 
 
 !~~~>  CALL Rosenbrock method
-   CALL ros_Integrator(Y, Tstart, Tend, Texit,   &
-        AbsTol, RelTol,                          &
+   CALL ros_Integrator(ICNTRL, Y, Tstart, Tend, Texit,   &
+        AbsTol, RelTol,                                  &
 !  Integration parameters
-        Autonomous, VectorTol, Max_no_steps,     &
-        Roundoff, Hmin, Hmax, Hstart,            &
-        FacMin, FacMax, FacRej, FacSafe,         &
+        Autonomous, VectorTol, Max_no_steps,             &
+        Roundoff, Hmin, Hmax, Hstart,                    &
+        FacMin, FacMax, FacRej, FacSafe,                 &
 !  Error indicator
         IERR)
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 CONTAINS !  SUBROUTINES internal to Rosenbrock
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  SUBROUTINE ros_ErrorMsg(Code,T,H,IERR)
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !    Handles all error messages
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
-  
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
    KPP_REAL, INTENT(IN) :: T, H
    INTEGER, INTENT(IN)  :: Code
    INTEGER, INTENT(OUT) :: IERR
-   
+
    IERR = Code
    PRINT * , &
-     'Forced exit from Rosenbrock due to the following error:' 
-     
+     'Forced exit from Rosenbrock due to the following error:'
+
    SELECT CASE (Code)
-    CASE (-1)    
+    CASE (-1)
       PRINT * , '--> Improper value for maximal no of steps'
-    CASE (-2)    
+    CASE (-2)
       PRINT * , '--> Selected Rosenbrock method not implemented'
-    CASE (-3)    
+    CASE (-3)
       PRINT * , '--> Hmin/Hmax/Hstart must be positive'
-    CASE (-4)    
+    CASE (-4)
       PRINT * , '--> FacMin/FacMax/FacRej must be positive'
-    CASE (-5) 
+    CASE (-5)
       PRINT * , '--> Improper tolerance values'
-    CASE (-6) 
+    CASE (-6)
       PRINT * , '--> No of steps exceeds maximum bound'
-    CASE (-7) 
+    CASE (-7)
       PRINT * , '--> Step size too small: T + 10*H = T', &
             ' or H < Roundoff'
-    CASE (-8)    
+    CASE (-8)
       PRINT * , '--> Matrix is repeatedly singular'
     CASE DEFAULT
       PRINT *, 'Unknown Error code: ', Code
    END SELECT
-   
+
    PRINT *, "T=", T, "and H=", H
-     
+
  END SUBROUTINE ros_ErrorMsg
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- SUBROUTINE ros_Integrator (Y, Tstart, Tend, T,  &
-        AbsTol, RelTol,                          &
+ SUBROUTINE ros_Integrator (ICNTRL, Y, Tstart, Tend, T,  &
+        AbsTol, RelTol,                                  &
 !~~~> Integration parameters
-        Autonomous, VectorTol, Max_no_steps,     &
-        Roundoff, Hmin, Hmax, Hstart,            &
-        FacMin, FacMax, FacRej, FacSafe,         &
+        Autonomous, VectorTol, Max_no_steps,             &
+        Roundoff, Hmin, Hmax, Hstart,                    &
+        FacMin, FacMax, FacRej, FacSafe,                 &
 !~~~> Error indicator
         IERR )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -436,7 +442,8 @@ CONTAINS !  SUBROUTINES internal to Rosenbrock
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   IMPLICIT NONE
-
+!~~~> Input: KPP runtime options
+   INTEGER,  INTENT(IN) :: ICNTRL(20)
 !~~~> Input: the initial condition at Tstart; Output: the solution at T
    KPP_REAL, INTENT(INOUT) :: Y(N)
 !~~~> Input: integration interval
@@ -455,7 +462,7 @@ CONTAINS !  SUBROUTINES internal to Rosenbrock
 ! ~~~~ Local variables
    KPP_REAL :: Ynew(N), Fcn0(N), Fcn(N)
    KPP_REAL :: K(N*ros_S), dFdT(N)
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
    KPP_REAL :: Jac0(N,N), Ghimj(N,N)
 #else
    KPP_REAL :: Jac0(LU_NONZERO), Ghimj(LU_NONZERO)
@@ -507,17 +514,17 @@ TimeLoop: DO WHILE ( (Direction > 0).AND.((T-Tend)+Roundoff <= ZERO) &
    H = MIN(H,ABS(Tend-T))
 
 !~~~>   Compute the function at current time
-   CALL FunTemplate(T,Y,Fcn0)
+   CALL FunTemplate( ICNTRL, T, Y, Fcn0 )
    ISTATUS(Nfun) = ISTATUS(Nfun) + 1
 
 !~~~>  Compute the function derivative with respect to T
    IF (.NOT.Autonomous) THEN
-      CALL ros_FunTimeDerivative ( T, Roundoff, Y, &
+      CALL ros_FunTimeDerivative (ICNTRL, T, Roundoff, Y, &
                 Fcn0, dFdT )
    END IF
 
 !~~~>   Compute the Jacobian at current time
-   CALL JacTemplate(T,Y,Jac0)
+   CALL JacTemplate( ICNTRL, T, Y, Jac0 )
    ISTATUS(Njac) = ISTATUS(Njac) + 1
 
 !~~~>  Repeat step calculation until current step accepted
@@ -549,7 +556,7 @@ Stage: DO istage = 1, ros_S
             K(N*(j-1)+1),1,Ynew,1)
          END DO
          Tau = T + ros_Alpha(istage)*Direction*H
-         CALL FunTemplate(Tau,Ynew,Fcn)
+         CALL FunTemplate( ICNTRL, Tau, Ynew, Fcn )
          ISTATUS(Nfun) = ISTATUS(Nfun) + 1
        END IF ! if istage == 1 elseif ros_NewF(istage)
        !slim: CALL WCOPY(N,Fcn,1,K(ioffset+1),1)
@@ -659,7 +666,7 @@ Stage: DO istage = 1, ros_S
 
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  SUBROUTINE ros_FunTimeDerivative ( T, Roundoff, Y, &
+  SUBROUTINE ros_FunTimeDerivative ( ICNTRL, T, Roundoff, Y, &
                 Fcn0, dFdT )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !~~~> The time partial derivative of the function by finite differences
@@ -667,6 +674,7 @@ Stage: DO istage = 1, ros_S
    IMPLICIT NONE
 
 !~~~> Input arguments
+   INTEGER,  INTENT(IN) :: ICNTRL(20)
    KPP_REAL, INTENT(IN) :: T, Roundoff, Y(N), Fcn0(N)
 !~~~> Output arguments
    KPP_REAL, INTENT(OUT) :: dFdT(N)
@@ -675,7 +683,7 @@ Stage: DO istage = 1, ros_S
    KPP_REAL, PARAMETER :: ONE = 1.0_dp, DeltaMin = 1.0E-6_dp
 
    Delta = SQRT(Roundoff)*MAX(DeltaMin,ABS(T))
-   CALL FunTemplate(T+Delta,Y,dFdT)
+   CALL FunTemplate( ICNTRL, T+Delta, Y, dFdT )
    ISTATUS(Nfun) = ISTATUS(Nfun) + 1
    CALL WAXPY(N,(-ONE),Fcn0,1,dFdT,1)
    CALL WSCAL(N,(ONE/Delta),dFdT,1)
@@ -697,19 +705,19 @@ Stage: DO istage = 1, ros_S
    IMPLICIT NONE
 
 !~~~> Input arguments
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
    KPP_REAL, INTENT(IN) ::  Jac0(N,N)
 #else
    KPP_REAL, INTENT(IN) ::  Jac0(LU_NONZERO)
-#endif   
+#endif
    KPP_REAL, INTENT(IN) ::  gam
    INTEGER, INTENT(IN) ::  Direction
 !~~~> Output arguments
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
    KPP_REAL, INTENT(OUT) :: Ghimj(N,N)
 #else
    KPP_REAL, INTENT(OUT) :: Ghimj(LU_NONZERO)
-#endif   
+#endif
    LOGICAL, INTENT(OUT) ::  Singular
    INTEGER, INTENT(OUT) ::  Pivot(N)
 !~~~> Inout arguments
@@ -725,7 +733,7 @@ Stage: DO istage = 1, ros_S
    DO WHILE (Singular)
 
 !~~~>    Construct Ghimj = 1/(H*gam) - Jac0
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
      !slim: CALL WCOPY(N*N,Jac0,1,Ghimj,1)
      !slim: CALL WSCAL(N*N,(-ONE),Ghimj,1)
      Ghimj = -Jac0
@@ -741,7 +749,7 @@ Stage: DO istage = 1, ros_S
      DO i=1,N
        Ghimj(LU_DIAG(i)) = Ghimj(LU_DIAG(i))+ghinv
      END DO
-#endif   
+#endif
 !~~~>    Compute LU decomposition
      CALL ros_Decomp( Ghimj, Pivot, ISING )
      IF (ISING == 0) THEN
@@ -772,17 +780,17 @@ Stage: DO istage = 1, ros_S
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    IMPLICIT NONE
 !~~~> Inout variables
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
    KPP_REAL, INTENT(INOUT) :: A(N,N)
-#else   
+#else
    KPP_REAL, INTENT(INOUT) :: A(LU_NONZERO)
 #endif
 !~~~> Output variables
    INTEGER, INTENT(OUT) :: Pivot(N), ISING
 
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
    CALL  DGETRF( N, N, A, N, Pivot, ISING )
-#else   
+#else
    CALL KppDecomp ( A, ISING )
    Pivot(1) = 1
 #endif
@@ -798,22 +806,22 @@ Stage: DO istage = 1, ros_S
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    IMPLICIT NONE
 !~~~> Input variables
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
    KPP_REAL, INTENT(IN) :: A(N,N)
    INTEGER :: ISING
-#else   
+#else
    KPP_REAL, INTENT(IN) :: A(LU_NONZERO)
 #endif
    INTEGER, INTENT(IN) :: Pivot(N)
 !~~~> InOut variables
    KPP_REAL, INTENT(INOUT) :: b(N)
 
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
    CALL  DGETRS( 'N', N , 1, A, N, Pivot, b, N, ISING )
    IF ( Info < 0 ) THEN
       PRINT*,"Error in DGETRS. ISING=",ISING
-   END IF  
-#else   
+   END IF
+#else
    CALL KppSolve( A, b )
 #endif
 
@@ -1178,7 +1186,7 @@ Stage: DO istage = 1, ros_S
 ! J. RANG and L. ANGERMANN
 ! NEW ROSENBROCK W-METHODS OF ORDER 3
 ! FOR PARTIAL DIFFERENTIAL ALGEBRAIC
-!        EQUATIONS OF INDEX 1                                             
+!        EQUATIONS OF INDEX 1
 ! BIT Numerical Mathematics (2005) 45: 761-787
 !  DOI: 10.1007/s10543-005-0035-y
 ! Table 4.1-4.2
@@ -1249,7 +1257,7 @@ END SUBROUTINE Rosenbrock
 
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-SUBROUTINE FunTemplate( T, Y, Ydot )
+SUBROUTINE FunTemplate( ICNTRL, T, Y, Ydot )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !  Template for the ODE function call.
 !  Updates the rate coefficients (and possibly the fixed species) at each call
@@ -1259,6 +1267,7 @@ SUBROUTINE FunTemplate( T, Y, Ydot )
  USE KPP_ROOT_Function, ONLY: Fun
  USE KPP_ROOT_Rates, ONLY: Update_SUN, Update_RCONST
 !~~~> Input variables
+   INTEGER :: ICNTRL(20)
    KPP_REAL :: T, Y(NVAR)
 !~~~> Output variables
    KPP_REAL :: Ydot(NVAR)
@@ -1267,8 +1276,8 @@ SUBROUTINE FunTemplate( T, Y, Ydot )
 
    Told = TIME
    TIME = T
-   CALL Update_SUN()
-   CALL Update_RCONST()
+   IF ( ICNTRL(15) == 3 ) CALL Update_SUN()
+   IF ( ICNTRL(15) >= 1 ) CALL Update_RCONST()
    CALL Fun( Y, FIX, RCONST, Ydot )
    TIME = Told
 
@@ -1276,7 +1285,7 @@ END SUBROUTINE FunTemplate
 
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-SUBROUTINE JacTemplate( T, Y, Jcb )
+SUBROUTINE JacTemplate( ICNTRL, T, Y, Jcb )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !  Template for the ODE Jacobian call.
 !  Updates the rate coefficients (and possibly the fixed species) at each call
@@ -1287,24 +1296,25 @@ SUBROUTINE JacTemplate( T, Y, Jcb )
  USE KPP_ROOT_LinearAlgebra
  USE KPP_ROOT_Rates, ONLY: Update_SUN, Update_RCONST
 !~~~> Input variables
+    INTEGER :: ICNTRL(20)
     KPP_REAL :: T, Y(NVAR)
 !~~~> Output variables
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
     KPP_REAL :: JV(LU_NONZERO), Jcb(NVAR,NVAR)
 #else
     KPP_REAL :: Jcb(LU_NONZERO)
-#endif   
+#endif
 !~~~> Local variables
     KPP_REAL :: Told
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
     INTEGER :: i, j
-#endif   
+#endif
 
     Told = TIME
     TIME = T
-    CALL Update_SUN()
-    CALL Update_RCONST()
-#ifdef FULL_ALGEBRA    
+    IF ( ICNTRL(15) == 3 ) CALL Update_SUN()
+    IF ( ICNTRL(15) >= 1 ) CALL Update_RCONST()
+#ifdef FULL_ALGEBRA
     CALL Jac_SP(Y, FIX, RCONST, JV)
     DO j=1,NVAR
       DO i=1,NVAR
@@ -1316,13 +1326,9 @@ SUBROUTINE JacTemplate( T, Y, Jcb )
     END DO
 #else
     CALL Jac_SP( Y, FIX, RCONST, Jcb )
-#endif   
+#endif
     TIME = Told
 
 END SUBROUTINE JacTemplate
 
 END MODULE KPP_ROOT_Integrator
-
-
-
-

--- a/int/rosenbrock_adj.f90
+++ b/int/rosenbrock_adj.f90
@@ -119,8 +119,8 @@ SUBROUTINE INTEGRATE_ADJ( NADJ, Y, Lambda, TIN, TOUT, &
    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
    !            =  4 ! Call Update_SUN from within the integrator
    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-   !            =  6 ! Not implemented
-   !            =  7 ! Not implemented
+   !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+   !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
    CALL Integrator_Update_Options( ICNTRL(15),          &
                                    Do_Update_RCONST,    &
                                    Do_Update_PHOTO,     &

--- a/int/rosenbrock_adj.f90
+++ b/int/rosenbrock_adj.f90
@@ -118,14 +118,19 @@ SUBROUTINE INTEGRATE_ADJ( NADJ, Y, Lambda, TIN, TOUT, &
    !            =  2 ! Call Update_PHOTO from within the integrator
    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
    !            =  4 ! Call Update_SUN from within the integrator
-   !            =  5 ! Call Update_SUN and Update_RCONST from within the int.
-   CALL Integrator_Update_Options( ICNTRL(15) )
+   !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
+   !            =  6 ! Not implemented
+   !            =  7 ! Not implemented
+   CALL Integrator_Update_Options( ICNTRL(15),          &
+                                   Do_Update_RCONST,    &
+                                   Do_Update_PHOTO,     &
+                                   Do_Update_Sun       )
 
+   ! Call the integrator
    CALL RosenbrockADJ(Y, NADJ, Lambda,                 &
          TIN, TOUT,                                    &
          ATOL, RTOL, ATOL_adj, RTOL_adj,               &
          RCNTRL, ICNTRL, RSTATUS, ISTATUS, IERR)
-
 
 !~~~> Debug option: show number of steps
 !    Ntotal = Ntotal + ISTATUS(Nstp)
@@ -255,13 +260,16 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
 !        ICNTRL(8)=1 : save LU factorization
 !        Note: if ICNTRL(7)=1 the LU factorization is *not* saved
 !
-!    ICNTRL(15) = -1 ! Do not call Update_* functions within the integrator
-!               =  0 ! Status quo
-!               =  1 ! Call Update_RCONST from within the integrator
-!               =  2 ! Call Update_PHOTO from within the integrator
-!               =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
-!               =  4 ! Call Update_SUN from within the integrator
-!               =  5 ! Call Update_SUN and Update_RCONST from within the int.
+!    ICNTRL(15) -> Toggles calling of Update_* functions w/in the integrator
+!        = -1 : Do not call Update_* functions within the integrator
+!        =  0 : Status quo
+!        =  1 : Call Update_RCONST from within the integrator
+!        =  2 : Call Update_PHOTO from within the integrator
+!        =  3 : Call Update_RCONST and Update_PHOTO from w/in the int.
+!        =  4 : Call Update_SUN from within the integrator
+!        =  5 : Call Update_SUN and Update_RCONST from within the int.
+!        =  6 : Not implemented
+!        =  7 : Not implemented
 !
 !~~~>  Real input parameters:
 !
@@ -2581,43 +2589,5 @@ SUBROUTINE HessTemplate( T, Y, Hes )
     TIME = Told
 
 END SUBROUTINE HessTemplate
-
-SUBROUTINE Integrator_Update_Options( option )
-
-!    option      -> determine whether to call Update_RCONST, Update_PHOTO,
-!                   and Update_SUN from within the integrator
-!        = -1 :   Do not call Update_* functions within the integrator
-!        =  0 :   Status quo: Call whichever functions are normally called
-!        =  1 :   Call Update_RCONST from within the integrator
-!        =  2 :   Call Update_PHOTO from within the integrator
-!        =  3 :   Call Update_RCONST and Update_PHOTO from within the int.
-!        =  4 :   Call Update_SUN from within the integrator
-!        =  5 :   Call Update_SUN and Update_RCONST from within the int.
-
-!~~~> Input variable
-  INTEGER, INTENT(IN) :: option
-
-  ! Option -1: turn off all Update_* calls within the integrator
-  IF ( option == -1 ) THEN
-     Do_Update_RCONST = .FALSE.
-     Do_Update_PHOTO  = .FALSE.
-     Do_Update_SUN    = .FALSE.
-     RETURN
-  ENDIF
-
-  ! Option 0: status quo: Call update functions if defined
-  IF ( option == 0 ) THEN
-     Do_Update_RCONST = .TRUE.
-     Do_Update_PHOTO  = .TRUE.
-     Do_Update_SUN    = .TRUE.
-     RETURN
-  ENDIF
-
-  ! Otherwise determine from the value passed
-  Do_Update_RCONST = ( IAND( option, 1 ) > 0 )
-  Do_Update_PHOTO  = ( IAND( option, 2 ) > 0 )
-  Do_Update_SUN    = ( IAND( option, 4 ) > 0 )
-
-END SUBROUTINE Integrator_Update_Options
 
 END MODULE KPP_ROOT_Integrator

--- a/int/rosenbrock_adj.f90
+++ b/int/rosenbrock_adj.f90
@@ -12,7 +12,7 @@
 !    (C)  Adrian Sandu, August 2004                                       !
 !    Virginia Polytechnic Institute and State University                  !
 !    Contact: sandu@cs.vt.edu                                             !
-!    Revised by Philipp Miehe and Adrian Sandu, May 2006                  ! 
+!    Revised by Philipp Miehe and Adrian Sandu, May 2006                  !
 !    This implementation is part of KPP - the Kinetic PreProcessor        !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
 
@@ -27,11 +27,18 @@ MODULE KPP_ROOT_Integrator
    USE KPP_ROOT_Jacobian
    USE KPP_ROOT_Hessian
    USE KPP_ROOT_Util
-   
+
    IMPLICIT NONE
    PUBLIC
    SAVE
-  
+
+!~~~> Flags to determine if we should call the UPDATE_* routines from within
+!~~~> the integrator.  If using KPP in an external model, you might want to
+!~~~> disable these calls (via ICNTRL(15)) to avoid excess computations.
+  LOGICAL :: Do_Update_RCONST
+  LOGICAL :: Do_Update_PHOTO
+  LOGICAL :: Do_Update_SUN
+
 !~~~>  Statistics on the work performed by the Rosenbrock method
    INTEGER, PARAMETER :: Nfun=1, Njac=2, Nstp=3, Nacc=4, &
                          Nrej=5, Ndec=6, Nsol=7, Nsng=8, &
@@ -47,14 +54,14 @@ SUBROUTINE INTEGRATE_ADJ( NADJ, Y, Lambda, TIN, TOUT, &
            ICNTRL_U, RCNTRL_U, ISTATUS_U, RSTATUS_U )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   IMPLICIT NONE        
-    
+   IMPLICIT NONE
+
 !~~~> Y - Concentrations
    KPP_REAL  :: Y(NVAR)
 !~~~> NADJ - No. of cost functionals for which adjoints
 !                are evaluated simultaneously
 !            If single cost functional is considered (like in
-!                most applications) simply set NADJ = 1      
+!                most applications) simply set NADJ = 1
    INTEGER NADJ
 !~~~> Lambda - Sensitivities w.r.t. concentrations
 !     Note: Lambda (1:NVAR,j) contains sensitivities of
@@ -63,7 +70,7 @@ SUBROUTINE INTEGRATE_ADJ( NADJ, Y, Lambda, TIN, TOUT, &
    KPP_REAL, INTENT(IN)  :: TIN  ! TIN  - Start Time
    KPP_REAL, INTENT(IN)  :: TOUT ! TOUT - End Time
 !~~~> Tolerances for adjoint calculations
-!     (used only for full continuous adjoint)   
+!     (used only for full continuous adjoint)
    KPP_REAL, INTENT(IN)  :: ATOL_adj(NVAR,NADJ), RTOL_adj(NVAR,NADJ)
 !~~~> Optional input parameters and statistics
    INTEGER,       INTENT(IN),  OPTIONAL :: ICNTRL_U(20)
@@ -81,19 +88,20 @@ SUBROUTINE INTEGRATE_ADJ( NADJ, Y, Lambda, TIN, TOUT, &
    RCNTRL(1:20)  = 0.0_dp
    ISTATUS(1:20) = 0
    RSTATUS(1:20) = 0.0_dp
-   
-   
+
+
 !~~~> fine-tune the integrator:
-!   ICNTRL(1) = 0       ! 0 = non-autonomous, 1 = autonomous
-!   ICNTRL(2) = 1       ! 0 = scalar, 1 = vector tolerances
-!   RCNTRL(3) = STEPMIN ! starting step
-!   ICNTRL(3) = 5       ! choice of the method for forward integration
-!   ICNTRL(6) = 1       ! choice of the method for continuous adjoint
-!   ICNTRL(7) = 2       ! 1=none, 2=discrete, 3=full continuous, 4=simplified continuous adjoint
-!   ICNTRL(8) = 1       ! Save fwd LU factorization: 0 = *don't* save, 1 = save
+! ICNTRL(1)  =  0       ! 0 = non-autonomous, 1 = autonomous
+! ICNTRL(2)  =  1       ! 0 = scalar, 1 = vector tolerances
+! RCNTRL(3)  =  STEPMIN ! starting step
+! ICNTRL(3)  =  5       ! choice of the method for forward integration
+! ICNTRL(6)  =  1       ! choice of the method for continuous adjoint
+! ICNTRL(7)  =  2       ! 1=none, 2=discrete, 3=full continuous,
+!                         ! 4=simplified continuous adjoint
+! ICNTRL(8)  =  1       ! Save fwd LU factorization: 0=*don't* save, 1=save
 
-
-   ! if optional parameters are given, and if they are >=0, then they overwrite default settings
+   ! if optional parameters are given, and if they are >=0, then
+   ! they overwrite default settings
    IF (PRESENT(ICNTRL_U)) THEN
      WHERE(ICNTRL_U(:) >= 0) ICNTRL(:) = ICNTRL_U(:)
    END IF
@@ -101,7 +109,18 @@ SUBROUTINE INTEGRATE_ADJ( NADJ, Y, Lambda, TIN, TOUT, &
      WHERE(RCNTRL_U(:) >= 0) RCNTRL(:) = RCNTRL_U(:)
    END IF
 
-   
+   ! Determine the settings of the Do_Update_* flags, which determine
+   ! whether or not we need to call Update_* routines in the integrator
+   ! (or not, if we are calling them from a higher-level)
+   ! ICNTRL(15) = -1 ! Do not call Update_* functions within the integrator
+   !            =  0 ! Status quo
+   !            =  1 ! Call Update_RCONST from within the integrator
+   !            =  2 ! Call Update_PHOTO from within the integrator
+   !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
+   !            =  4 ! Call Update_SUN from within the integrator
+   !            =  5 ! Call Update_SUN and Update_RCONST from within the int.
+   CALL Integrator_Update_Options( ICNTRL(15) )
+
    CALL RosenbrockADJ(Y, NADJ, Lambda,                 &
          TIN, TOUT,                                    &
          ATOL, RTOL, ATOL_adj, RTOL_adj,               &
@@ -111,7 +130,7 @@ SUBROUTINE INTEGRATE_ADJ( NADJ, Y, Lambda, TIN, TOUT, &
 !~~~> Debug option: show number of steps
 !    Ntotal = Ntotal + ISTATUS(Nstp)
 !    WRITE(6,777) ISTATUS(Nstp),Ntotal,VAR(ind_O3),VAR(ind_NO2)
-!777 FORMAT('NSTEPS=',I6,' (',I6,')  O3=',E24.14,'  NO2=',E24.14)    
+!777 FORMAT('NSTEPS=',I6,' (',I6,')  O3=',E24.14,'  NO2=',E24.14)
 
    IF (IERR < 0) THEN
      print *,'RosenbrockADJ: Unsucessful step at T=',  &
@@ -119,7 +138,7 @@ SUBROUTINE INTEGRATE_ADJ( NADJ, Y, Lambda, TIN, TOUT, &
    END IF
 
    STEPMIN = RSTATUS(Nhexit)
-   ! if optional parameters are given for output 
+   ! if optional parameters are given for output
    !         copy to them to return information
    IF (PRESENT(ISTATUS_U)) ISTATUS_U(:) = ISTATUS(:)
    IF (PRESENT(RSTATUS_U)) RSTATUS_U(:) = RSTATUS(:)
@@ -133,7 +152,7 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
            AbsTol, RelTol, AbsTol_adj, RelTol_adj,     &
            RCNTRL, ICNTRL, RSTATUS, ISTATUS, IERR)
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!   
+!
 !    ADJ = Adjoint of the Tangent Linear Model of a Rosenbrock Method
 !
 !    Solves the system y'=F(t,y) using a RosenbrockADJ method defined by:
@@ -143,40 +162,40 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
 !     Y_i = Y0 + \sum_{j=1}^{i-1} A(i,j)*K_j
 !     G * K_i = Fun( T_i, Y_i ) + \sum_{j=1}^S C(i,j)/H * K_j +
 !         gamma(i)*dF/dT(t0, Y0)
-!     Y1 = Y0 + \sum_{j=1}^S M(j)*K_j 
+!     Y1 = Y0 + \sum_{j=1}^S M(j)*K_j
 !
 !    For details on RosenbrockADJ methods and their implementation consult:
 !      E. Hairer and G. Wanner
 !      "Solving ODEs II. Stiff and differential-algebraic problems".
-!      Springer series in computational mathematics, Springer-Verlag, 1996.  
-!    The codes contained in the book inspired this implementation.       
+!      Springer series in computational mathematics, Springer-Verlag, 1996.
+!    The codes contained in the book inspired this implementation.
 !
 !    (C)  Adrian Sandu, August 2004
-!    Virginia Polytechnic Institute and State University    
+!    Virginia Polytechnic Institute and State University
 !    Contact: sandu@cs.vt.edu
-!    Revised by Philipp Miehe and Adrian Sandu, May 2006                   
+!    Revised by Philipp Miehe and Adrian Sandu, May 2006
 !    This implementation is part of KPP - the Kinetic PreProcessor
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!    
-!~~~>   INPUT ARGUMENTS: 
-!    
+!
+!~~~>   INPUT ARGUMENTS:
+!
 !-     Y(NVAR)    = vector of initial conditions (at T=Tstart)
-!      NADJ       -> dimension of linearized system, 
+!      NADJ       -> dimension of linearized system,
 !                   i.e. the number of sensitivity coefficients
 !-     Lambda(NVAR,NADJ) -> vector of initial sensitivity conditions (at T=Tstart)
 !-    [Tstart,Tend]  = time range of integration
-!     (if Tstart>Tend the integration is performed backwards in time)  
+!     (if Tstart>Tend the integration is performed backwards in time)
 !-    RelTol, AbsTol = user precribed accuracy
-!- SUBROUTINE Fun( T, Y, Ydot ) = ODE function, 
-!                       returns Ydot = Y' = F(T,Y) 
+!- SUBROUTINE Fun( T, Y, Ydot ) = ODE function,
+!                       returns Ydot = Y' = F(T,Y)
 !- SUBROUTINE Jac( T, Y, Jcb ) = Jacobian of the ODE function,
-!                       returns Jcb = dF/dY 
+!                       returns Jcb = dF/dY
 !-    ICNTRL(1:10)    = integer inputs parameters
 !-    RCNTRL(1:10)    = real inputs parameters
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !
-!~~~>     OUTPUT ARGUMENTS:  
-!     
+!~~~>     OUTPUT ARGUMENTS:
+!
 !-    Y(NVAR)    -> vector of final states (at T->Tend)
 !-    Lambda(NVAR,NADJ) -> vector of final sensitivities (at T=Tend)
 !-    ICNTRL(11:20)   -> integer output parameters
@@ -193,7 +212,7 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
 !           = -7 : Step size too small
 !           = -8 : Matrix is repeatedly singular
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-! 
+!
 !~~~>     INPUT PARAMETERS:
 !
 !    Note: For input parameters equal to zero the default values of the
@@ -208,8 +227,8 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
 !    ICNTRL(3)  -> selection of a particular Rosenbrock method
 !        = 0 :  default method is Rodas3
 !        = 1 :  method is  Ros2
-!        = 2 :  method is  Ros3 
-!        = 3 :  method is  Ros4 
+!        = 2 :  method is  Ros3
+!        = 3 :  method is  Ros4
 !        = 4 :  method is  Rodas3
 !        = 5:   method is  Rodas4
 !
@@ -219,14 +238,14 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
 !    ICNTRL(6)  -> selection of a particular Rosenbrock method for the
 !                continuous adjoint integration - for cts adjoint it
 !                can be different than the forward method ICNTRL(3)
-!         Note 1: to avoid interpolation errors (which can be huge!) 
+!         Note 1: to avoid interpolation errors (which can be huge!)
 !                   it is recommended to use only ICNTRL(7) = 2 or 4
 !         Note 2: the performance of the full continuous adjoint
 !                   strongly depends on the forward solution accuracy Abs/RelTol
 !
 !    ICNTRL(7) -> Type of adjoint algorithm
 !         = 0 : default is discrete adjoint ( of method ICNTRL(3) )
-!         = 1 : no adjoint       
+!         = 1 : no adjoint
 !         = 2 : discrete adjoint ( of method ICNTRL(3) )
 !         = 3 : fully adaptive continuous adjoint ( with method ICNTRL(6) )
 !         = 4 : simplified continuous adjoint ( with method ICNTRL(6) )
@@ -236,15 +255,23 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
 !        ICNTRL(8)=1 : save LU factorization
 !        Note: if ICNTRL(7)=1 the LU factorization is *not* saved
 !
+!    ICNTRL(15) = -1 ! Do not call Update_* functions within the integrator
+!               =  0 ! Status quo
+!               =  1 ! Call Update_RCONST from within the integrator
+!               =  2 ! Call Update_PHOTO from within the integrator
+!               =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
+!               =  4 ! Call Update_SUN from within the integrator
+!               =  5 ! Call Update_SUN and Update_RCONST from within the int.
+!
 !~~~>  Real input parameters:
 !
 !    RCNTRL(1)  -> Hmin, lower bound for the integration step size
-!          It is strongly recommended to keep Hmin = ZERO 
+!          It is strongly recommended to keep Hmin = ZERO
 !
 !    RCNTRL(2)  -> Hmax, upper bound for the integration step size
 !
 !    RCNTRL(3)  -> Hstart, starting value for the integration step size
-!          
+!
 !    RCNTRL(4)  -> FacMin, lower bound on step decrease factor (default=0.2)
 !
 !    RCNTRL(5)  -> FacMax, upper bound on step increase factor (default=6)
@@ -252,7 +279,7 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
 !    RCNTRL(6)  -> FacRej, step decrease factor after multiple rejections
 !            (default=0.1)
 !
-!    RCNTRL(7)  -> FacSafe, by which the new step is slightly smaller 
+!    RCNTRL(7)  -> FacSafe, by which the new step is slightly smaller
 !         than the predicted value  (default=0.9)
 !
 !    RCNTRL(8)  -> ThetaMin. If Newton convergence rate smaller
@@ -260,7 +287,7 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
 !                  (default=0.001)
 !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-! 
+!
 !~~~>     OUTPUT PARAMETERS:
 !
 !    Note: each call to RosenbrockADJ adds the corrent no. of fcn calls
@@ -276,15 +303,15 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
 !    ISTATUS(7) = No. of forward/backward substitutions
 !    ISTATUS(8) = No. of singular matrix decompositions
 !
-!    RSTATUS(1)  -> Texit, the time corresponding to the 
+!    RSTATUS(1)  -> Texit, the time corresponding to the
 !                   computed Y upon return
 !    RSTATUS(2)  -> Hexit, last accepted step before exit
-!    For multiple restarts, use Hexit as Hstart in the following run 
+!    For multiple restarts, use Hexit as Hstart in the following run
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   IMPLICIT NONE
-   
-!~~~>  Arguments   
+
+!~~~>  Arguments
    KPP_REAL, INTENT(INOUT) :: Y(NVAR)
    INTEGER, INTENT(IN)          :: NADJ
    KPP_REAL, INTENT(INOUT) :: Lambda(NVAR,NADJ)
@@ -312,12 +339,12 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
    KPP_REAL, DIMENSION(:),   POINTER :: chk_H, chk_T
    KPP_REAL, DIMENSION(:,:), POINTER :: chk_Y, chk_K, chk_J
    KPP_REAL, DIMENSION(:,:), POINTER :: chk_dY, chk_d2Y
-!~~~>  Local variables     
+!~~~>  Local variables
    KPP_REAL :: Roundoff, FacMin, FacMax, FacRej, FacSafe
    KPP_REAL :: Hmin, Hmax, Hstart
    KPP_REAL :: Texit
    INTEGER :: i, UplimTol, Max_no_steps
-   INTEGER :: AdjointType, CadjMethod 
+   INTEGER :: AdjointType, CadjMethod
    LOGICAL :: Autonomous, VectorTol, SaveLU
 !~~~>   Parameters
    KPP_REAL, PARAMETER :: ZERO = 0.0d0, ONE  = 1.0d0
@@ -326,7 +353,7 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
 !~~~>  Initialize statistics
    ISTATUS(1:20) = 0
    RSTATUS(1:20) = ZERO
-   
+
 !~~~>  Autonomous or time dependent ODE. Default is time dependent.
    Autonomous = .NOT.(ICNTRL(1) == 0)
 
@@ -335,7 +362,7 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
    IF (ICNTRL(2) == 0) THEN
       VectorTol = .TRUE.
       UplimTol  = NVAR
-   ELSE 
+   ELSE
       VectorTol = .FALSE.
       UplimTol  = 1
    END IF
@@ -353,20 +380,20 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
      CASE (5)
        CALL Rodas4
      CASE DEFAULT
-       PRINT * , 'Unknown Rosenbrock method: ICNTRL(3)=',ICNTRL(3) 
+       PRINT * , 'Unknown Rosenbrock method: ICNTRL(3)=',ICNTRL(3)
        CALL ros_ErrorMsg(-2,Tstart,ZERO,IERR)
        RETURN
    END SELECT
-   
+
 !~~~>   The maximum number of steps admitted
    IF (ICNTRL(4) == 0) THEN
       Max_no_steps = bufsize - 1
    ELSEIF (Max_no_steps > 0) THEN
       Max_no_steps=ICNTRL(4)
-   ELSE 
+   ELSE
       PRINT * ,'User-selected max no. of steps: ICNTRL(4)=',ICNTRL(4)
       CALL ros_ErrorMsg(-1,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
 
 !~~~>  The particular Rosenbrock method chosen for integrating the cts adjoint
@@ -374,98 +401,98 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
       CadjMethod = 4
    ELSEIF ( (ICNTRL(6) >= 1).AND.(ICNTRL(6) <= 5) ) THEN
       CadjMethod = ICNTRL(6)
-   ELSE  
+   ELSE
       PRINT * , 'Unknown CADJ Rosenbrock method: ICNTRL(6)=', CadjMethod
       CALL ros_ErrorMsg(-2,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
- 
+
 !~~~>  Discrete or continuous adjoint formulation
    IF ( ICNTRL(7) == 0 ) THEN
        AdjointType = Adj_discrete
    ELSEIF ( (ICNTRL(7) >= 1).AND.(ICNTRL(7) <= 4) ) THEN
        AdjointType = ICNTRL(7)
-   ELSE  
+   ELSE
       PRINT * , 'User-selected adjoint type: ICNTRL(7)=', AdjointType
       CALL ros_ErrorMsg(-9,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
 
 !~~~> Save or not the forward LU factorization
-      SaveLU = (ICNTRL(8) /= 0) 
+      SaveLU = (ICNTRL(8) /= 0)
 
- 
-!~~~>  Unit roundoff (1+Roundoff>1)  
+
+!~~~>  Unit roundoff (1+Roundoff>1)
    Roundoff = WLAMCH('E')
 
 !~~~>  Lower bound on the step size: (positive value)
    IF (RCNTRL(1) == ZERO) THEN
       Hmin = ZERO
-   ELSEIF (RCNTRL(1) > ZERO) THEN 
+   ELSEIF (RCNTRL(1) > ZERO) THEN
       Hmin = RCNTRL(1)
-   ELSE  
+   ELSE
       PRINT * , 'User-selected Hmin: RCNTRL(1)=', RCNTRL(1)
       CALL ros_ErrorMsg(-3,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
 !~~~>  Upper bound on the step size: (positive value)
    IF (RCNTRL(2) == ZERO) THEN
       Hmax = ABS(Tend-Tstart)
    ELSEIF (RCNTRL(2) > ZERO) THEN
       Hmax = MIN(ABS(RCNTRL(2)),ABS(Tend-Tstart))
-   ELSE  
+   ELSE
       PRINT * , 'User-selected Hmax: RCNTRL(2)=', RCNTRL(2)
       CALL ros_ErrorMsg(-3,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
 !~~~>  Starting step size: (positive value)
    IF (RCNTRL(3) == ZERO) THEN
       Hstart = MAX(Hmin,DeltaMin)
    ELSEIF (RCNTRL(3) > ZERO) THEN
       Hstart = MIN(ABS(RCNTRL(3)),ABS(Tend-Tstart))
-   ELSE  
+   ELSE
       PRINT * , 'User-selected Hstart: RCNTRL(3)=', RCNTRL(3)
       CALL ros_ErrorMsg(-3,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
-!~~~>  Step size can be changed s.t.  FacMin < Hnew/Hold < FacMax 
+!~~~>  Step size can be changed s.t.  FacMin < Hnew/Hold < FacMax
    IF (RCNTRL(4) == ZERO) THEN
       FacMin = 0.2d0
    ELSEIF (RCNTRL(4) > ZERO) THEN
       FacMin = RCNTRL(4)
-   ELSE  
+   ELSE
       PRINT * , 'User-selected FacMin: RCNTRL(4)=', RCNTRL(4)
       CALL ros_ErrorMsg(-4,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
    IF (RCNTRL(5) == ZERO) THEN
       FacMax = 6.0d0
    ELSEIF (RCNTRL(5) > ZERO) THEN
       FacMax = RCNTRL(5)
-   ELSE  
+   ELSE
       PRINT * , 'User-selected FacMax: RCNTRL(5)=', RCNTRL(5)
       CALL ros_ErrorMsg(-4,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
 !~~~>   FacRej: Factor to decrease step after 2 succesive rejections
    IF (RCNTRL(6) == ZERO) THEN
       FacRej = 0.1d0
    ELSEIF (RCNTRL(6) > ZERO) THEN
       FacRej = RCNTRL(6)
-   ELSE  
+   ELSE
       PRINT * , 'User-selected FacRej: RCNTRL(6)=', RCNTRL(6)
       CALL ros_ErrorMsg(-4,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
 !~~~>   FacSafe: Safety Factor in the computation of new step size
    IF (RCNTRL(7) == ZERO) THEN
       FacSafe = 0.9d0
    ELSEIF (RCNTRL(7) > ZERO) THEN
       FacSafe = RCNTRL(7)
-   ELSE  
+   ELSE
       PRINT * , 'User-selected FacSafe: RCNTRL(7)=', RCNTRL(7)
       CALL ros_ErrorMsg(-4,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
 !~~~>  Check if tolerances are reasonable
     DO i=1,UplimTol
@@ -477,8 +504,8 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
         RETURN
       END IF
     END DO
-     
- 
+
+
 !~~~>  Allocate checkpoint space or open checkpoint files
    IF (AdjointType == Adj_discrete) THEN
        CALL ros_AllocateDBuffers( ros_S )
@@ -486,10 +513,9 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
            (AdjointType == Adj_simple_continuous) ) THEN
        CALL ros_AllocateCBuffers
    END IF
-   
-!~~~>  CALL Forward Rosenbrock method   
-   CALL ros_FwdInt(Y,Tstart,Tend,Texit,          & 
-        AbsTol, RelTol,                          & 
+
+!~~~>  CALL Forward Rosenbrock method
+   CALL ros_FwdInt( Y, Tstart, Tend, Texit,  AbsTol,  RelTol, &
 !  Error indicator
         IERR)
 
@@ -497,7 +523,7 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
    PRINT*,'Step=',Nstp,' Acc=',Nacc,   &
         ' Rej=',Nrej, ' Singular=',Nsng
 
-!~~~>  If Forward integration failed return   
+!~~~>  If Forward integration failed return
    IF (IERR<0) RETURN
 
 !~~~>   Initialize the particular Rosenbrock method for continuous adjoint
@@ -516,18 +542,18 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
        CALL Rodas4
      CASE DEFAULT
        PRINT * , 'Unknown Rosenbrock method: ICNTRL(3)=', ICNTRL(3)
-       CALL ros_ErrorMsg(-2,Tstart,ZERO,IERR) 
-       RETURN     
+       CALL ros_ErrorMsg(-2,Tstart,ZERO,IERR)
+       RETURN
    END SELECT
    END IF
 
-   SELECT CASE (AdjointType)   
-   CASE (Adj_discrete)   
+   SELECT CASE (AdjointType)
+   CASE (Adj_discrete)
      CALL ros_DadjInt (                          &
         NADJ, Lambda,                            &
         Tstart, Tend, Texit,                     &
         IERR )
-   CASE (Adj_continuous) 
+   CASE (Adj_continuous)
      CALL ros_CadjInt (                          &
         NADJ, Lambda,                            &
         Tend, Tstart, Texit,                     &
@@ -551,7 +577,7 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
            (AdjointType == Adj_simple_continuous) ) THEN
       CALL ros_FreeCBuffers
    END IF
-   
+
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 CONTAINS !  Procedures internal to RosenbrockADJ
@@ -563,24 +589,24 @@ CONTAINS !  Procedures internal to RosenbrockADJ
 !~~~>  Allocate buffer space for discrete adjoint
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    INTEGER :: i, S
-   
+
    ALLOCATE( chk_H(bufsize), STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed allocation of buffer H'; STOP
-   END IF   
+   END IF
    ALLOCATE( chk_T(bufsize), STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed allocation of buffer T'; STOP
-   END IF   
+   END IF
    ALLOCATE( chk_Y(NVAR*S,bufsize), STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed allocation of buffer Y'; STOP
-   END IF   
+   END IF
    ALLOCATE( chk_K(NVAR*S,bufsize), STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed allocation of buffer K'; STOP
-   END IF  
-   IF (SaveLU) THEN 
+   END IF
+   IF (SaveLU) THEN
 #ifdef FULL_ALGEBRA
      ALLOCATE( chk_J(NVAR*NVAR,bufsize), STAT=i )
 #else
@@ -588,8 +614,8 @@ CONTAINS !  Procedures internal to RosenbrockADJ
 #endif
      IF (i/=0) THEN
         PRINT*,'Failed allocation of buffer J'; STOP
-     END IF   
-   END IF   
+     END IF
+   END IF
 
  END SUBROUTINE ros_AllocateDBuffers
 
@@ -599,30 +625,30 @@ CONTAINS !  Procedures internal to RosenbrockADJ
 !~~~>  Dallocate buffer space for discrete adjoint
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    INTEGER :: i
-   
+
    DEALLOCATE( chk_H, STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed deallocation of buffer H'; STOP
-   END IF   
+   END IF
    DEALLOCATE( chk_T, STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed deallocation of buffer T'; STOP
-   END IF   
+   END IF
    DEALLOCATE( chk_Y, STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed deallocation of buffer Y'; STOP
-   END IF   
+   END IF
    DEALLOCATE( chk_K, STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed deallocation of buffer K'; STOP
-   END IF   
-   IF (SaveLU) THEN 
+   END IF
+   IF (SaveLU) THEN
      DEALLOCATE( chk_J, STAT=i )
      IF (i/=0) THEN
         PRINT*,'Failed deallocation of buffer J'; STOP
-     END IF   
-   END IF   
- 
+     END IF
+   END IF
+
  END SUBROUTINE ros_FreeDBuffers
 
 
@@ -631,28 +657,28 @@ CONTAINS !  Procedures internal to RosenbrockADJ
 !~~~>  Allocate buffer space for continuous adjoint
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    INTEGER :: i
-   
+
    ALLOCATE( chk_H(bufsize), STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed allocation of buffer H'; STOP
-   END IF   
+   END IF
    ALLOCATE( chk_T(bufsize), STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed allocation of buffer T'; STOP
-   END IF   
+   END IF
    ALLOCATE( chk_Y(NVAR,bufsize), STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed allocation of buffer Y'; STOP
-   END IF   
+   END IF
    ALLOCATE( chk_dY(NVAR,bufsize), STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed allocation of buffer dY'; STOP
-   END IF   
+   END IF
    ALLOCATE( chk_d2Y(NVAR,bufsize), STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed allocation of buffer d2Y'; STOP
-   END IF   
- 
+   END IF
+
  END SUBROUTINE ros_AllocateCBuffers
 
 
@@ -661,28 +687,28 @@ CONTAINS !  Procedures internal to RosenbrockADJ
 !~~~>  Dallocate buffer space for continuous adjoint
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    INTEGER :: i
-   
+
    DEALLOCATE( chk_H, STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed deallocation of buffer H'; STOP
-   END IF   
+   END IF
    DEALLOCATE( chk_T, STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed deallocation of buffer T'; STOP
-   END IF   
+   END IF
    DEALLOCATE( chk_Y, STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed deallocation of buffer Y'; STOP
-   END IF   
+   END IF
    DEALLOCATE( chk_dY, STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed deallocation of buffer dY'; STOP
-   END IF   
+   END IF
    DEALLOCATE( chk_d2Y, STAT=i )
    IF (i/=0) THEN
       PRINT*,'Failed deallocation of buffer d2Y'; STOP
-   END IF   
- 
+   END IF
+
  END SUBROUTINE ros_FreeCBuffers
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -695,33 +721,33 @@ CONTAINS !  Procedures internal to RosenbrockADJ
    INTEGER       :: P(NVAR)
 #ifdef FULL_ALGEBRA
    KPP_REAL :: E(NVAR,NVAR)
-#else       
+#else
    KPP_REAL :: E(LU_NONZERO)
 #endif
-   
+
    stack_ptr = stack_ptr + 1
    IF ( stack_ptr > bufsize ) THEN
      PRINT*,'Push failed: buffer overflow'
      STOP
-   END IF  
+   END IF
    chk_H( stack_ptr ) = H
    chk_T( stack_ptr ) = T
    !CALL WCOPY(NVAR*S,Ystage,1,chk_Y(1,stack_ptr),1)
    !CALL WCOPY(NVAR*S,K,1,chk_K(1,stack_ptr),1)
    chk_Y(1:NVAR*S,stack_ptr) = Ystage(1:NVAR*S)
    chk_K(1:NVAR*S,stack_ptr) = K(1:NVAR*S)
-   IF (SaveLU) THEN 
+   IF (SaveLU) THEN
 #ifdef FULL_ALGEBRA
        chk_J(1:NVAR,1:NVAR,stack_ptr) = E(1:NVAR,1:NVAR)
        chk_P(1:NVAR,stack_ptr)        = P(1:NVAR)
-#else       
+#else
        chk_J(1:LU_NONZERO,stack_ptr)  = E(1:LU_NONZERO)
 #endif
     END IF
-  
+
   END SUBROUTINE ros_DPush
-  
-   
+
+
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE ros_DPop( S, T, H, Ystage, K, E, P )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -733,14 +759,14 @@ CONTAINS !  Procedures internal to RosenbrockADJ
    INTEGER       :: P(NVAR)
 #ifdef FULL_ALGEBRA
    KPP_REAL :: E(NVAR,NVAR)
-#else       
+#else
    KPP_REAL :: E(LU_NONZERO)
 #endif
-   
+
    IF ( stack_ptr <= 0 ) THEN
      PRINT*,'Pop failed: empty buffer'
      STOP
-   END IF  
+   END IF
    H = chk_H( stack_ptr )
    T = chk_T( stack_ptr )
    !CALL WCOPY(NVAR*S,chk_Y(1,stack_ptr),1,Ystage,1)
@@ -752,15 +778,15 @@ CONTAINS !  Procedures internal to RosenbrockADJ
 #ifdef FULL_ALGEBRA
        E(1:NVAR,1:NVAR) = chk_J(1:NVAR,1:NVAR,stack_ptr)
        P(1:NVAR)        = chk_P(1:NVAR,stack_ptr)
-#else       
+#else
        E(1:LU_NONZERO)  = chk_J(1:LU_NONZERO,stack_ptr)
 #endif
     END IF
 
    stack_ptr = stack_ptr - 1
-  
+
   END SUBROUTINE ros_DPop
- 
+
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE ros_CPush( T, H, Y, dY, d2Y )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -768,12 +794,12 @@ CONTAINS !  Procedures internal to RosenbrockADJ
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
    KPP_REAL :: T, H, Y(NVAR), dY(NVAR), d2Y(NVAR)
-   
+
    stack_ptr = stack_ptr + 1
    IF ( stack_ptr > bufsize ) THEN
      PRINT*,'Push failed: buffer overflow'
      STOP
-   END IF  
+   END IF
    chk_H( stack_ptr ) = H
    chk_T( stack_ptr ) = T
    !CALL WCOPY(NVAR,Y,1,chk_Y(1,stack_ptr),1)
@@ -783,8 +809,8 @@ CONTAINS !  Procedures internal to RosenbrockADJ
    chk_dY(1:NVAR,stack_ptr)  = dY(1:NVAR)
    chk_d2Y(1:NVAR,stack_ptr) = d2Y(1:NVAR)
   END SUBROUTINE ros_CPush
-  
-   
+
+
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE ros_CPop( T, H, Y, dY, d2Y )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -792,11 +818,11 @@ CONTAINS !  Procedures internal to RosenbrockADJ
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
    KPP_REAL :: T, H, Y(NVAR), dY(NVAR), d2Y(NVAR)
-   
+
    IF ( stack_ptr <= 0 ) THEN
      PRINT*,'Pop failed: empty buffer'
      STOP
-   END IF  
+   END IF
    H = chk_H( stack_ptr )
    T = chk_T( stack_ptr )
    !CALL WCOPY(NVAR,chk_Y(1,stack_ptr),1,Y,1)
@@ -807,89 +833,89 @@ CONTAINS !  Procedures internal to RosenbrockADJ
    d2Y(1:NVAR) = chk_d2Y(1:NVAR,stack_ptr)
 
    stack_ptr = stack_ptr - 1
-  
+
   END SUBROUTINE ros_CPop
 
 
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  SUBROUTINE ros_ErrorMsg(Code,T,H,IERR)
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !    Handles all error messages
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
-  
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
    KPP_REAL, INTENT(IN) :: T, H
    INTEGER, INTENT(IN)  :: Code
    INTEGER, INTENT(OUT) :: IERR
-   
+
    IERR = Code
    PRINT * , &
-     'Forced exit from RosenbrockADJ due to the following error:' 
-     
+     'Forced exit from RosenbrockADJ due to the following error:'
+
    SELECT CASE (Code)
-    CASE (-1)    
+    CASE (-1)
       PRINT * , '--> Improper value for maximal no of steps'
-    CASE (-2)    
+    CASE (-2)
       PRINT * , '--> Selected RosenbrockADJ method not implemented'
-    CASE (-3)    
+    CASE (-3)
       PRINT * , '--> Hmin/Hmax/Hstart must be positive'
-    CASE (-4)    
+    CASE (-4)
       PRINT * , '--> FacMin/FacMax/FacRej must be positive'
-    CASE (-5) 
+    CASE (-5)
       PRINT * , '--> Improper tolerance values'
-    CASE (-6) 
+    CASE (-6)
       PRINT * , '--> No of steps exceeds maximum buffer bound'
-    CASE (-7) 
+    CASE (-7)
       PRINT * , '--> Step size too small: T + 10*H = T', &
             ' or H < Roundoff'
-    CASE (-8)    
+    CASE (-8)
       PRINT * , '--> Matrix is repeatedly singular'
-    CASE (-9)    
+    CASE (-9)
       PRINT * , '--> Improper type of adjoint selected'
     CASE DEFAULT
       PRINT *, 'Unknown Error code: ', Code
    END SELECT
-   
+
    PRINT *, "T=", T, "and H=", H
-     
+
  END SUBROUTINE ros_ErrorMsg
-   
-     
-   
+
+
+
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- SUBROUTINE ros_FwdInt (Y,                       &
-        Tstart, Tend, T,                         &
-        AbsTol, RelTol,                          &
+ SUBROUTINE ros_FwdInt ( Y,      &
+        Tstart, Tend, T,         &
+        AbsTol, RelTol,          &
 !~~~> Error indicator
         IERR )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!   Template for the implementation of a generic RosenbrockADJ method 
-!      defined by ros_S (no of stages)  
+!   Template for the implementation of a generic RosenbrockADJ method
+!      defined by ros_S (no of stages)
 !      and its coefficients ros_{A,C,M,E,Alpha,Gamma}
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   IMPLICIT NONE
-   
-!~~~> Input: the initial condition at Tstart; Output: the solution at T   
+
+!~~~> Input: the initial condition at Tstart; Output: the solution at T
    KPP_REAL, INTENT(INOUT) :: Y(NVAR)
-!~~~> Input: integration interval   
-   KPP_REAL, INTENT(IN) :: Tstart,Tend      
-!~~~> Output: time at which the solution is returned (T=Tend if success)   
-   KPP_REAL, INTENT(OUT) ::  T      
-!~~~> Input: tolerances      
+!~~~> Input: integration interval
+   KPP_REAL, INTENT(IN) :: Tstart,Tend
+!~~~> Output: time at which the solution is returned (T=Tend if success)
+   KPP_REAL, INTENT(OUT) ::  T
+!~~~> Input: tolerances
    KPP_REAL, INTENT(IN) ::  AbsTol(NVAR), RelTol(NVAR)
 !~~~> Output: Error indicator
    INTEGER, INTENT(OUT) :: IERR
-! ~~~~ Local variables        
-   KPP_REAL :: Ynew(NVAR), Fcn0(NVAR), Fcn(NVAR) 
+! ~~~~ Local variables
+   KPP_REAL :: Ynew(NVAR), Fcn0(NVAR), Fcn(NVAR)
    KPP_REAL :: K(NVAR*ros_S), dFdT(NVAR)
    KPP_REAL, DIMENSION(:), POINTER :: Ystage
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
    KPP_REAL :: Jac0(NVAR,NVAR),  Ghimj(NVAR,NVAR)
 #else
    KPP_REAL :: Jac0(LU_NONZERO), Ghimj(LU_NONZERO)
 #endif
-   KPP_REAL :: H, Hnew, HC, HG, Fac, Tau 
+   KPP_REAL :: H, Hnew, HC, HG, Fac, Tau
    KPP_REAL :: Err, Yerr(NVAR)
    INTEGER :: Pivot(NVAR), Direction, ioffset, i, j, istage
    LOGICAL :: RejectLastH, RejectMoreH, Singular
@@ -904,8 +930,8 @@ CONTAINS !  Procedures internal to RosenbrockADJ
           PRINT*,'Allocation of Ystage failed'
           STOP
         END IF
-   END IF   
-   
+   END IF
+
 !~~~>  Initial preparations
    T = Tstart
    RSTATUS(Nhexit) = ZERO
@@ -921,12 +947,12 @@ CONTAINS !  Procedures internal to RosenbrockADJ
 
    RejectLastH=.FALSE.
    RejectMoreH=.FALSE.
-   
-!~~~> Time loop begins below 
+
+!~~~> Time loop begins below
 
 TimeLoop: DO WHILE ( (Direction > 0).AND.((T-Tend)+Roundoff <= ZERO) &
-       .OR. (Direction < 0).AND.((Tend-T)+Roundoff <= ZERO) ) 
-      
+       .OR. (Direction < 0).AND.((Tend-T)+Roundoff <= ZERO) )
+
    IF ( ISTATUS(Nstp) > Max_no_steps ) THEN  ! Too many steps
       CALL ros_ErrorMsg(-6,T,H,IERR)
       RETURN
@@ -935,28 +961,27 @@ TimeLoop: DO WHILE ( (Direction > 0).AND.((T-Tend)+Roundoff <= ZERO) &
       CALL ros_ErrorMsg(-7,T,H,IERR)
       RETURN
    END IF
-   
-!~~~>  Limit H if necessary to avoid going beyond Tend   
+
+!~~~>  Limit H if necessary to avoid going beyond Tend
    RSTATUS(Nhexit) = H
    H = MIN(H,ABS(Tend-T))
 
 !~~~>   Compute the function at current time
-   CALL FunTemplate(T,Y,Fcn0)
-   ISTATUS(Nfun) = ISTATUS(Nfun) + 1 
+   CALL FunTemplate( T, Y, Fcn0 )
+   ISTATUS(Nfun) = ISTATUS(Nfun) + 1
 
 !~~~>  Compute the function derivative with respect to T
    IF (.NOT.Autonomous) THEN
-      CALL ros_FunTimeDerivative ( T, Roundoff, Y, &
-                Fcn0, dFdT )
+      CALL ros_FunTimeDerivative ( T, Roundoff, Y, Fcn0, dFdT )
    END IF
-  
+
 !~~~>   Compute the Jacobian at current time
-   CALL JacTemplate(T,Y,Jac0)
+   CALL JacTemplate( T, Y, Jac0 )
    ISTATUS(Njac) = ISTATUS(Njac) + 1
- 
+
 !~~~>  Repeat step calculation until current step accepted
-UntilAccepted: DO  
-   
+UntilAccepted: DO
+
    CALL ros_PrepareMatrix(H,Direction,ros_Gamma(1), &
           Jac0,Ghimj,Pivot,Singular)
    IF (Singular) THEN ! More than 5 consecutive failed decompositions
@@ -966,10 +991,10 @@ UntilAccepted: DO
 
 !~~~>   Compute the stages
 Stage: DO istage = 1, ros_S
-      
+
       ! Current istage offset. Current istage vector is K(ioffset+1:ioffset+NVAR)
        ioffset = NVAR*(istage-1)
-      
+
       ! For the 1st istage the function has been computed previously
        IF ( istage == 1 ) THEN
          CALL WCOPY(NVAR,Fcn0,1,Fcn,1)
@@ -977,23 +1002,23 @@ Stage: DO istage = 1, ros_S
             ! CALL WCOPY(NVAR,Y,1,Ystage(1),1)
             Ystage(1:NVAR) = Y(1:NVAR)
             CALL WCOPY(NVAR,Y,1,Ynew,1)
-         END IF   
+         END IF
       ! istage>1 and a new function evaluation is needed at the current istage
        ELSEIF ( ros_NewF(istage) ) THEN
          CALL WCOPY(NVAR,Y,1,Ynew,1)
          DO j = 1, istage-1
            CALL WAXPY(NVAR,ros_A((istage-1)*(istage-2)/2+j), &
-            K(NVAR*(j-1)+1),1,Ynew,1) 
+            K(NVAR*(j-1)+1),1,Ynew,1)
          END DO
          Tau = T + ros_Alpha(istage)*Direction*H
-         CALL FunTemplate(Tau,Ynew,Fcn)
+         CALL FunTemplate( Tau, Ynew, Fcn )
          ISTATUS(Nfun) = ISTATUS(Nfun) + 1
        END IF ! if istage == 1 elseif ros_NewF(istage)
       ! save stage solution every time even if ynew is not updated
        IF ( ( istage > 1 ).AND.(AdjointType == Adj_discrete) ) THEN
          ! CALL WCOPY(NVAR,Ynew,1,Ystage(ioffset+1),1)
          Ystage(ioffset+1:ioffset+NVAR) = Ynew(1:NVAR)
-       END IF   
+       END IF
        CALL WCOPY(NVAR,Fcn,1,K(ioffset+1),1)
        DO j = 1, istage-1
          HC = ros_C((istage-1)*(istage-2)/2+j)/(Direction*H)
@@ -1004,26 +1029,26 @@ Stage: DO istage = 1, ros_S
          CALL WAXPY(NVAR,HG,dFdT,1,K(ioffset+1),1)
        END IF
        CALL ros_Solve('N', Ghimj, Pivot, K(ioffset+1))
-      
-   END DO Stage     
-            
 
-!~~~>  Compute the new solution 
+   END DO Stage
+
+
+!~~~>  Compute the new solution
    CALL WCOPY(NVAR,Y,1,Ynew,1)
    DO j=1,ros_S
          CALL WAXPY(NVAR,ros_M(j),K(NVAR*(j-1)+1),1,Ynew,1)
    END DO
 
-!~~~>  Compute the error estimation 
+!~~~>  Compute the error estimation
    CALL WSCAL(NVAR,ZERO,Yerr,1)
-   DO j=1,ros_S     
+   DO j=1,ros_S
         CALL WAXPY(NVAR,ros_E(j),K(NVAR*(j-1)+1),1,Yerr,1)
-   END DO 
+   END DO
    Err = ros_ErrorNorm ( Y, Ynew, Yerr, AbsTol, RelTol, VectorTol )
 
 !~~~> New step size is bounded by FacMin <= Hnew/H <= FacMax
    Fac  = MIN(FacMax,MAX(FacMin,FacSafe/Err**(ONE/ros_ELO)))
-   Hnew = H*Fac  
+   Hnew = H*Fac
 
 !~~~>  Check the error magnitude and adjust step size
    ISTATUS(Nstp) = ISTATUS(Nstp) + 1
@@ -1035,101 +1060,99 @@ Stage: DO istage = 1, ros_S
            (AdjointType == Adj_simple_continuous) ) THEN
 #ifdef FULL_ALGEBRA
           K = MATMUL(Jac0,Fcn0)
-#else           
+#else
           CALL Jac_SP_Vec( Jac0, Fcn0, K(1) )
-#endif          
+#endif
           IF (.NOT. Autonomous) THEN
              CALL WAXPY(NVAR,ONE,dFdT,1,K(1),1)
-          END IF   
+          END IF
           CALL ros_CPush( T, H, Y, Fcn0, K(1) )
-      END IF      
+      END IF
       CALL WCOPY(NVAR,Ynew,1,Y,1)
       T = T + Direction*H
       Hnew = MAX(Hmin,MIN(Hnew,Hmax))
       IF (RejectLastH) THEN  ! No step size increase after a rejected step
-         Hnew = MIN(Hnew,H) 
-      END IF   
+         Hnew = MIN(Hnew,H)
+      END IF
       RSTATUS(Nhexit) = H
       RSTATUS(Nhnew)  = Hnew
       RSTATUS(Ntexit) = T
-      RejectLastH = .FALSE.  
+      RejectLastH = .FALSE.
       RejectMoreH = .FALSE.
-      H = Hnew      
+      H = Hnew
       EXIT UntilAccepted ! EXIT THE LOOP: WHILE STEP NOT ACCEPTED
    ELSE           !~~~> Reject step
       IF (RejectMoreH) THEN
          Hnew = H*FacRej
-      END IF   
+      END IF
       RejectMoreH = RejectLastH
       RejectLastH = .TRUE.
       H = Hnew
       IF (ISTATUS(Nacc) >= 1) THEN
          ISTATUS(Nrej) = ISTATUS(Nrej) + 1
-      END IF    
+      END IF
    END IF ! Err <= 1
 
-   END DO UntilAccepted 
+   END DO UntilAccepted
 
-   END DO TimeLoop 
-   
+   END DO TimeLoop
+
 !~~~> Save last state: only needed for continuous adjoint
    IF ( (AdjointType == Adj_continuous) .OR. &
        (AdjointType == Adj_simple_continuous) ) THEN
-       CALL FunTemplate(T,Y,Fcn0)
+       CALL FunTemplate( T, Y, Fcn0 )
        ISTATUS(Nfun) = ISTATUS(Nfun) + 1
-       CALL JacTemplate(T,Y,Jac0)
+       CALL JacTemplate( T, Y, Jac0 )
        ISTATUS(Njac) = ISTATUS(Njac) + 1
 #ifdef FULL_ALGEBRA
        K = MATMUL(Jac0,Fcn0)
 #else
        CALL Jac_SP_Vec( Jac0, Fcn0, K(1) )
-#endif       
+#endif
        IF (.NOT. Autonomous) THEN
-           CALL ros_FunTimeDerivative ( T, Roundoff, Y, &
-                Fcn0, dFdT )
+           CALL ros_FunTimeDerivative ( T, Roundoff, Y, Fcn0, dFdT )
            CALL WAXPY(NVAR,ONE,dFdT,1,K(1),1)
-       END IF   
+       END IF
        CALL ros_CPush( T, H, Y, Fcn0, K(1) )
 !~~~> Deallocate stage buffer: only needed for discrete adjoint
-   ELSEIF (AdjointType == Adj_discrete) THEN 
+   ELSEIF (AdjointType == Adj_discrete) THEN
         DEALLOCATE(Ystage, STAT=i)
         IF (i/=0) THEN
           PRINT*,'Deallocation of Ystage failed'
           STOP
         END IF
-   END IF   
-   
+   END IF
+
 !~~~> Succesful exit
    IERR = 1  !~~~> The integration was successful
 
   END SUBROUTINE ros_FwdInt
-   
-     
+
+
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- SUBROUTINE ros_DadjInt (                        &
-        NADJ, Lambda,                            &
-        Tstart, Tend, T,                         &
+ SUBROUTINE ros_DadjInt ( NADJ, Lambda,       &
+        Tstart, Tend, T,                      &
 !~~~> Error indicator
         IERR )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!   Template for the implementation of a generic RosenbrockSOA method 
-!      defined by ros_S (no of stages)  
+!   Template for the implementation of a generic RosenbrockSOA method
+!      defined by ros_S (no of stages)
 !      and its coefficients ros_{A,C,M,E,Alpha,Gamma}
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   IMPLICIT NONE
-   
-!~~~> Input: the initial condition at Tstart; Output: the solution at T   
+
+!~~~> Input: the initial condition at Tstart; Output: the solution at T
    INTEGER, INTENT(IN)     :: NADJ
-!~~~> First order adjoint   
+!~~~> First order adjoint
    KPP_REAL, INTENT(INOUT) :: Lambda(NVAR,NADJ)
-!!~~~> Input: integration interval   
-   KPP_REAL, INTENT(IN) :: Tstart,Tend      
-!~~~> Output: time at which the solution is returned (T=Tend if success)   
-   KPP_REAL, INTENT(OUT) ::  T      
+!!~~~> Input: integration interval
+   KPP_REAL, INTENT(IN) :: Tstart,Tend
+!~~~> Output: time at which the solution is returned (T=Tend if success)
+   KPP_REAL, INTENT(OUT) ::  T
 !~~~> Output: Error indicator
    INTEGER, INTENT(OUT) :: IERR
-! ~~~~ Local variables        
+! ~~~~ Local variables
    KPP_REAL :: Ystage(NVAR*ros_S), K(NVAR*ros_S)
    KPP_REAL :: U(NVAR*ros_S,NADJ), V(NVAR*ros_S,NADJ)
 #ifdef FULL_ALGEBRA
@@ -1139,33 +1162,33 @@ Stage: DO istage = 1, ros_S
 #endif
    KPP_REAL :: Hes0(NHESS)
    KPP_REAL :: Tmp(NVAR), Tmp2(NVAR)
-   KPP_REAL :: H, HC, HA, Tau 
+   KPP_REAL :: H, HC, HA, Tau
    INTEGER :: Pivot(NVAR), Direction
    INTEGER :: i, j, m, istage, istart, jstart
 !~~~>  Local parameters
-   KPP_REAL, PARAMETER :: ZERO = 0.0d0, ONE  = 1.0d0 
+   KPP_REAL, PARAMETER :: ZERO = 0.0d0, ONE  = 1.0d0
    KPP_REAL, PARAMETER :: DeltaMin = 1.0d-5
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   
-   
+
+
    IF (Tend  >=  Tstart) THEN
      Direction = +1
    ELSE
      Direction = -1
-   END IF               
+   END IF
 
-!~~~> Time loop begins below 
+!~~~> Time loop begins below
 TimeLoop: DO WHILE ( stack_ptr > 0 )
-        
+
    !~~~>  Recover checkpoints for stage values and vectors
    CALL ros_DPop( ros_S, T, H, Ystage, K, Ghimj, Pivot )
 
 !   ISTATUS(Nstp) = ISTATUS(Nstp) + 1
 
-!~~~>    Compute LU decomposition 
+!~~~>    Compute LU decomposition
    IF (.NOT.SaveLU) THEN
-     CALL JacTemplate(T,Ystage(1),Ghimj)
+     CALL JacTemplate( T, Ystage(1), Ghimj )
      ISTATUS(Njac) = ISTATUS(Njac) + 1
      Tau = ONE/(Direction*H*ros_Gamma(1))
 #ifdef FULL_ALGEBRA
@@ -1181,16 +1204,16 @@ TimeLoop: DO WHILE ( stack_ptr > 0 )
 #endif
      CALL ros_Decomp( Ghimj, Pivot, j )
    END IF
-            
+
 !~~~>   Compute Hessian at the beginning of the interval
-   CALL HessTemplate(T,Ystage(1),Hes0)
-   
+   CALL HessTemplate( T, Ystage(1), Hes0 )
+
 !~~~>   Compute the stages
 Stage: DO istage = ros_S, 1, -1
-      
-      !~~~> Current istage first entry 
+
+      !~~~> Current istage first entry
        istart = NVAR*(istage-1) + 1
-      
+
       !~~~> Compute U
        DO m = 1,NADJ
          CALL WCOPY(NVAR,Lambda(1,m),1,U(istart,m),1)
@@ -1201,36 +1224,36 @@ Stage: DO istage = ros_S, 1, -1
          HA = ros_A((j-1)*(j-2)/2+istage)
          HC = ros_C((j-1)*(j-2)/2+istage)/(Direction*H)
          DO m = 1,NADJ
-           CALL WAXPY(NVAR,HA,V(jstart,m),1,U(istart,m),1) 
-           CALL WAXPY(NVAR,HC,U(jstart,m),1,U(istart,m),1) 
+           CALL WAXPY(NVAR,HA,V(jstart,m),1,U(istart,m),1)
+           CALL WAXPY(NVAR,HC,U(jstart,m),1,U(istart,m),1)
          END DO ! m=1:NADJ
        END DO
        DO m = 1,NADJ
          CALL ros_Solve('T', Ghimj, Pivot, U(istart,m))
        END DO ! m=1:NADJ
-      !~~~> Compute V 
+      !~~~> Compute V
        Tau = T + ros_Alpha(istage)*Direction*H
-       CALL JacTemplate(Tau,Ystage(istart),Jac)
+       CALL JacTemplate( Tau, Ystage(istart), Jac )
        ISTATUS(Njac) = ISTATUS(Njac) + 1
        DO m = 1,NADJ
 #ifdef FULL_ALGEBRA
          V(istart:istart+NVAR-1,m) = MATMUL(TRANSPOSE(Jac),U(istart:istart+NVAR-1,m))
 #else
-         CALL JacTR_SP_Vec(Jac,U(istart,m),V(istart,m)) 
-#endif         
+         CALL JacTR_SP_Vec(Jac,U(istart,m),V(istart,m))
+#endif
        END DO ! m=1:NADJ
-             
-   END DO Stage     
+
+   END DO Stage
 
    IF (.NOT.Autonomous) THEN
-!~~~>  Compute the Jacobian derivative with respect to T. 
+!~~~>  Compute the Jacobian derivative with respect to T.
 !      Last "Jac" computed for stage 1
       CALL ros_JacTimeDerivative ( T, Roundoff, Ystage(1), Jac, dJdT )
    END IF
 
-!~~~>  Compute the new solution 
-   
-      !~~~>  Compute Lambda 
+!~~~>  Compute the new solution
+
+      !~~~>  Compute Lambda
       DO istage=1,ros_S
          istart = NVAR*(istage-1) + 1
          DO m = 1,NADJ
@@ -1249,30 +1272,30 @@ Stage: DO istage = ros_S, 1, -1
            DO istage = 1, ros_S
              istart = NVAR*(istage-1) + 1
              CALL WAXPY(NVAR,ros_Gamma(istage),U(istart,m),1,Tmp,1)
-           END DO  
+           END DO
 #ifdef FULL_ALGEBRA
            Tmp2 = MATMUL(TRANSPOSE(dJdT),Tmp)
 #else
-           CALL JacTR_SP_Vec(dJdT,Tmp,Tmp2) 
-#endif           
+           CALL JacTR_SP_Vec(dJdT,Tmp,Tmp2)
+#endif
            CALL WAXPY(NVAR,H,Tmp2,1,Lambda(1,m),1)
          END DO ! m=1:NADJ
       END IF ! .NOT.Autonomous
- 
 
-   END DO TimeLoop 
-   
+
+   END DO TimeLoop
+
 !~~~> Save last state
-   
+
 !~~~> Succesful exit
    IERR = 1  !~~~> The integration was successful
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   END SUBROUTINE ros_DadjInt
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   
-   
-    
+
+
+
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  SUBROUTINE ros_CadjInt (                        &
         NADJ, Y,                                 &
@@ -1281,64 +1304,63 @@ Stage: DO istage = ros_S, 1, -1
 !~~~> Error indicator
         IERR )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!   Template for the implementation of a generic RosenbrockADJ method 
-!      defined by ros_S (no of stages)  
+!   Template for the implementation of a generic RosenbrockADJ method
+!      defined by ros_S (no of stages)
 !      and its coefficients ros_{A,C,M,E,Alpha,Gamma}
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   IMPLICIT NONE
-   
-!~~~> Input: the initial condition at Tstart; Output: the solution at T   
+!~~~> Input: the initial condition at Tstart; Output: the solution at T
    INTEGER, INTENT(IN) :: NADJ
    KPP_REAL, INTENT(INOUT) :: Y(NVAR,NADJ)
-!~~~> Input: integration interval   
-   KPP_REAL, INTENT(IN) :: Tstart,Tend      
-!~~~> Input: adjoint tolerances   
+!~~~> Input: integration interval
+   KPP_REAL, INTENT(IN) :: Tstart,Tend
+!~~~> Input: adjoint tolerances
    KPP_REAL, INTENT(IN) :: AbsTol_adj(NVAR,NADJ), RelTol_adj(NVAR,NADJ)
-!~~~> Output: time at which the solution is returned (T=Tend if success)   
-   KPP_REAL, INTENT(OUT) ::  T      
+!~~~> Output: time at which the solution is returned (T=Tend if success)
+   KPP_REAL, INTENT(OUT) ::  T
 !~~~> Output: Error indicator
    INTEGER, INTENT(OUT) :: IERR
-! ~~~~ Local variables        
+! ~~~~ Local variables
    KPP_REAL :: Y0(NVAR)
-   KPP_REAL :: Ynew(NVAR,NADJ), Fcn0(NVAR,NADJ), Fcn(NVAR,NADJ) 
+   KPP_REAL :: Ynew(NVAR,NADJ), Fcn0(NVAR,NADJ), Fcn(NVAR,NADJ)
    KPP_REAL :: K(NVAR*ros_S,NADJ), dFdT(NVAR,NADJ)
 #ifdef FULL_ALGEBRA
    KPP_REAL, DIMENSION(NVAR,NVAR)  :: Jac0, Ghimj, Jac, dJdT
 #else
    KPP_REAL, DIMENSION(LU_NONZERO) :: Jac0, Ghimj, Jac, dJdT
-#endif   
-   KPP_REAL :: H, Hnew, HC, HG, Fac, Tau 
+#endif
+   KPP_REAL :: H, Hnew, HC, HG, Fac, Tau
    KPP_REAL :: Err, Yerr(NVAR,NADJ)
    INTEGER :: Pivot(NVAR), Direction, ioffset, j, istage, iadj
    LOGICAL :: RejectLastH, RejectMoreH, Singular
 !~~~>  Local parameters
-   KPP_REAL, PARAMETER :: ZERO = 0.0d0, ONE  = 1.0d0 
+   KPP_REAL, PARAMETER :: ZERO = 0.0d0, ONE  = 1.0d0
    KPP_REAL, PARAMETER :: DeltaMin = 1.0d-5
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   
+
 !~~~>  Initial preparations
    T = Tstart
    RSTATUS(Nhexit) = 0.0_dp
    H = MIN( MAX(ABS(Hmin),ABS(Hstart)) , ABS(Hmax) )
    IF (ABS(H) <= 10.0_dp*Roundoff) H = DeltaMin
-   
+
    IF (Tend  >=  Tstart) THEN
      Direction = +1
    ELSE
      Direction = -1
-   END IF               
+   END IF
    H = Direction*H
 
    RejectLastH=.FALSE.
    RejectMoreH=.FALSE.
-   
-!~~~> Time loop begins below 
+
+!~~~> Time loop begins below
 
 TimeLoop: DO WHILE ( (Direction > 0).AND.((T-Tend)+Roundoff <= ZERO) &
-       .OR. (Direction < 0).AND.((Tend-T)+Roundoff <= ZERO) ) 
-      
+       .OR. (Direction < 0).AND.((Tend-T)+Roundoff <= ZERO) )
+
    IF ( ISTATUS(Nstp) > Max_no_steps ) THEN  ! Too many steps
       CALL ros_ErrorMsg(-6,T,H,IERR)
       RETURN
@@ -1347,21 +1369,20 @@ TimeLoop: DO WHILE ( (Direction > 0).AND.((T-Tend)+Roundoff <= ZERO) &
       CALL ros_ErrorMsg(-7,T,H,IERR)
       RETURN
    END IF
-   
-!~~~>  Limit H if necessary to avoid going beyond Tend   
+
+!~~~>  Limit H if necessary to avoid going beyond Tend
    RSTATUS(Nhexit) = H
    H = MIN(H,ABS(Tend-T))
 
 !~~~>   Interpolate forward solution
-   CALL ros_cadj_Y( T, Y0 )     
+   CALL ros_cadj_Y( T, Y0 )
 !~~~>   Compute the Jacobian at current time
    CALL JacTemplate(T, Y0, Jac0)
    ISTATUS(Njac) = ISTATUS(Njac) + 1
-   
+
 !~~~>  Compute the function derivative with respect to T
    IF (.NOT.Autonomous) THEN
-      CALL ros_JacTimeDerivative ( T, Roundoff, Y0, &
-                Jac0, dJdT )
+      CALL ros_JacTimeDerivative ( T, Roundoff, Y0, Jac0, dJdT )
       DO iadj = 1, NADJ
 #ifdef FULL_ALGEBRA
         dFdT(1:NVAR,iadj) = MATMUL(TRANSPOSE(dJdT),Y(1:NVAR,iadj))
@@ -1385,10 +1406,10 @@ TimeLoop: DO WHILE ( (Direction > 0).AND.((T-Tend)+Roundoff <= ZERO) &
      CALL JacTR_SP_Vec(Jac0,Y(1,iadj),Fcn0(1,iadj))
 #endif
    END DO
-    
+
 !~~~>  Repeat step calculation until current step accepted
-UntilAccepted: DO  
-   
+UntilAccepted: DO
+
    CALL ros_PrepareMatrix(H,Direction,ros_Gamma(1), &
           Jac0,Ghimj,Pivot,Singular)
    IF (Singular) THEN ! More than 5 consecutive failed decompositions
@@ -1398,10 +1419,10 @@ UntilAccepted: DO
 
 !~~~>   Compute the stages
 Stage: DO istage = 1, ros_S
-      
+
       ! Current istage offset. Current istage vector is K(ioffset+1:ioffset+NVAR)
        ioffset = NVAR*(istage-1)
-      
+
       ! For the 1st istage the function has been computed previously
        IF ( istage == 1 ) THEN
          DO iadj = 1, NADJ
@@ -1413,14 +1434,14 @@ Stage: DO istage = 1, ros_S
          DO j = 1, istage-1
            DO iadj = 1, NADJ
              CALL WAXPY(NVAR,ros_A((istage-1)*(istage-2)/2+j), &
-                K(NVAR*(j-1)+1,iadj),1,Ynew(1,iadj),1) 
-           END DO       
+                K(NVAR*(j-1)+1,iadj),1,Ynew(1,iadj),1)
+           END DO
          END DO
          Tau = T + ros_Alpha(istage)*Direction*H
          ! CALL FunTemplate(Tau,Ynew,Fcn)
          ! ISTATUS(Nfun) = ISTATUS(Nfun) + 1
-         CALL ros_cadj_Y( Tau, Y0 )     
-         CALL JacTemplate(Tau, Y0, Jac)
+         CALL ros_cadj_Y( Tau, Y0 )
+         CALL JacTemplate( Tau, Y0, Jac )
          ISTATUS(Njac) = ISTATUS(Njac) + 1
 #ifdef FULL_ALGEBRA
          Jac(1:NVAR,1:NVAR) = -Jac(1:NVAR,1:NVAR)
@@ -1456,11 +1477,11 @@ Stage: DO istage = 1, ros_S
        DO iadj = 1, NADJ
          CALL ros_Solve('T', Ghimj, Pivot, K(ioffset+1,iadj))
        END DO
-      
-   END DO Stage     
-            
 
-!~~~>  Compute the new solution 
+   END DO Stage
+
+
+!~~~>  Compute the new solution
    DO iadj = 1, NADJ
       CALL WCOPY(NVAR,Y(1,iadj),1,Ynew(1,iadj),1)
       DO j=1,ros_S
@@ -1468,21 +1489,21 @@ Stage: DO istage = 1, ros_S
       END DO
    END DO
 
-!~~~>  Compute the error estimation 
+!~~~>  Compute the error estimation
    CALL WSCAL(NVAR*NADJ,ZERO,Yerr,1)
-   DO j=1,ros_S     
+   DO j=1,ros_S
        DO iadj = 1, NADJ
         CALL WAXPY(NVAR,ros_E(j),K(NVAR*(j-1)+1,iadj),1,Yerr(1,iadj),1)
        END DO
    END DO
-!~~~> Max error among all adjoint components    
+!~~~> Max error among all adjoint components
    iadj = 1
    Err = ros_ErrorNorm ( Y(1,iadj), Ynew(1,iadj), Yerr(1,iadj), &
               AbsTol_adj(1,iadj), RelTol_adj(1,iadj), VectorTol )
 
 !~~~> New step size is bounded by FacMin <= Hnew/H <= FacMax
    Fac  = MIN(FacMax,MAX(FacMin,FacSafe/Err**(ONE/ros_ELO)))
-   Hnew = H*Fac  
+   Hnew = H*Fac
 
 !~~~>  Check the error magnitude and adjust step size
 !   ISTATUS(Nstp) = ISTATUS(Nstp) + 1
@@ -1492,106 +1513,105 @@ Stage: DO istage = 1, ros_S
       T = T + Direction*H
       Hnew = MAX(Hmin,MIN(Hnew,Hmax))
       IF (RejectLastH) THEN  ! No step size increase after a rejected step
-         Hnew = MIN(Hnew,H) 
-      END IF   
+         Hnew = MIN(Hnew,H)
+      END IF
       RSTATUS(Nhexit) = H
       RSTATUS(Nhnew)  = Hnew
       RSTATUS(Ntexit) = T
-      RejectLastH = .FALSE.  
+      RejectLastH = .FALSE.
       RejectMoreH = .FALSE.
-      H = Hnew      
+      H = Hnew
       EXIT UntilAccepted ! EXIT THE LOOP: WHILE STEP NOT ACCEPTED
    ELSE           !~~~> Reject step
       IF (RejectMoreH) THEN
          Hnew = H*FacRej
-      END IF   
+      END IF
       RejectMoreH = RejectLastH
       RejectLastH = .TRUE.
       H = Hnew
       IF (ISTATUS(Nacc) >= 1) THEN
          ISTATUS(Nrej) = ISTATUS(Nrej) + 1
-      END IF    
+      END IF
    END IF ! Err <= 1
 
-   END DO UntilAccepted 
+   END DO UntilAccepted
 
-   END DO TimeLoop 
-      
+   END DO TimeLoop
+
 !~~~> Succesful exit
    IERR = 1  !~~~> The integration was successful
 
   END SUBROUTINE ros_CadjInt
-  
-     
+
+
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- SUBROUTINE ros_SimpleCadjInt (                  &
-        NADJ, Y,                                 &
-        Tstart, Tend, T,                         &
+ SUBROUTINE ros_SimpleCadjInt (     &
+        NADJ, Y,                    &
+        Tstart, Tend, T,            &
 !~~~> Error indicator
         IERR )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!   Template for the implementation of a generic RosenbrockADJ method 
-!      defined by ros_S (no of stages)  
+!   Template for the implementation of a generic RosenbrockADJ method
+!      defined by ros_S (no of stages)
 !      and its coefficients ros_{A,C,M,E,Alpha,Gamma}
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   IMPLICIT NONE
-   
-!~~~> Input: the initial condition at Tstart; Output: the solution at T   
+
+!~~~> Input: the initial condition at Tstart; Output: the solution at T
    INTEGER, INTENT(IN) :: NADJ
    KPP_REAL, INTENT(INOUT) :: Y(NVAR,NADJ)
-!~~~> Input: integration interval   
-   KPP_REAL, INTENT(IN) :: Tstart,Tend      
-!~~~> Output: time at which the solution is returned (T=Tend if success)   
-   KPP_REAL, INTENT(OUT) ::  T      
+!~~~> Input: integration interval
+   KPP_REAL, INTENT(IN) :: Tstart,Tend
+!~~~> Output: time at which the solution is returned (T=Tend if success)
+   KPP_REAL, INTENT(OUT) ::  T
 !~~~> Output: Error indicator
    INTEGER, INTENT(OUT) :: IERR
-! ~~~~ Local variables        
+! ~~~~ Local variables
    KPP_REAL :: Y0(NVAR)
-   KPP_REAL :: Ynew(NVAR,NADJ), Fcn0(NVAR,NADJ), Fcn(NVAR,NADJ) 
+   KPP_REAL :: Ynew(NVAR,NADJ), Fcn0(NVAR,NADJ), Fcn(NVAR,NADJ)
    KPP_REAL :: K(NVAR*ros_S,NADJ), dFdT(NVAR,NADJ)
 #ifdef FULL_ALGEBRA
    KPP_REAL,DIMENSION(NVAR,NVAR)  :: Jac0, Ghimj, Jac, dJdT
-#else   
+#else
    KPP_REAL,DIMENSION(LU_NONZERO) :: Jac0, Ghimj, Jac, dJdT
-#endif   
-   KPP_REAL :: H, HC, HG, Tau 
+#endif
+   KPP_REAL :: H, HC, HG, Tau
    KPP_REAL :: ghinv
    INTEGER :: Pivot(NVAR), Direction, ioffset, i, j, istage, iadj
    INTEGER :: istack
 !~~~>  Local parameters
-   KPP_REAL, PARAMETER :: ZERO = 0.0d0, ONE  = 1.0d0 
+   KPP_REAL, PARAMETER :: ZERO = 0.0d0, ONE  = 1.0d0
    KPP_REAL, PARAMETER :: DeltaMin = 1.0d-5
 !~~~>  Locally called functions
 !    KPP_REAL WLAMCH
 !    EXTERNAL WLAMCH
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   
+
 !~~~>  INITIAL PREPARATIONS
-   
+
    IF (Tend  >=  Tstart) THEN
      Direction = -1
    ELSE
      Direction = +1
-   END IF               
-   
-!~~~> Time loop begins below 
+   END IF
+
+!~~~> Time loop begins below
 TimeLoop: DO istack = stack_ptr,2,-1
-        
+
    T = chk_T(istack)
    H = chk_H(istack-1)
    !CALL WCOPY(NVAR,chk_Y(1,istack),1,Y0,1)
    Y0(1:NVAR) = chk_Y(1:NVAR,istack)
-   
+
 !~~~>   Compute the Jacobian at current time
-   CALL JacTemplate(T, Y0, Jac0)
+   CALL JacTemplate( T, Y0, Jac0 )
    ISTATUS(Njac) = ISTATUS(Njac) + 1
-   
+
 !~~~>  Compute the function derivative with respect to T
    IF (.NOT.Autonomous) THEN
-      CALL ros_JacTimeDerivative ( T, Roundoff, Y0, &
-                Jac0, dJdT )
+      CALL ros_JacTimeDerivative ( T, Roundoff, Y0, Jac0, dJdT )
       DO iadj = 1, NADJ
 #ifdef FULL_ALGEBRA
         dFdT(1:NVAR,iadj) = MATMUL(TRANSPOSE(dJdT),Y(1:NVAR,iadj))
@@ -1615,7 +1635,7 @@ TimeLoop: DO istack = stack_ptr,2,-1
      CALL JacTR_SP_Vec(Jac0,Y(1,iadj),Fcn0(1,iadj))
 #endif
    END DO
-   
+
 !~~~>    Construct Ghimj = 1/(H*ham) - Jac0
      ghinv = ONE/(Direction*H*ros_Gamma(1))
 #ifdef FULL_ALGEBRA
@@ -1630,7 +1650,7 @@ TimeLoop: DO istack = stack_ptr,2,-1
        Ghimj(LU_DIAG(i)) = Ghimj(LU_DIAG(i))+ghinv
      END DO
 #endif
-!~~~>    Compute LU decomposition 
+!~~~>    Compute LU decomposition
      CALL ros_Decomp( Ghimj, Pivot, j )
      IF (j /= 0) THEN
        CALL ros_ErrorMsg(-8,T,H,IERR)
@@ -1640,10 +1660,10 @@ TimeLoop: DO istack = stack_ptr,2,-1
 
 !~~~>   Compute the stages
 Stage: DO istage = 1, ros_S
-      
+
       ! Current istage offset. Current istage vector is K(ioffset+1:ioffset+NVAR)
        ioffset = NVAR*(istage-1)
-      
+
       ! For the 1st istage the function has been computed previously
        IF ( istage == 1 ) THEN
          DO iadj = 1, NADJ
@@ -1655,14 +1675,14 @@ Stage: DO istage = 1, ros_S
          DO j = 1, istage-1
            DO iadj = 1, NADJ
              CALL WAXPY(NVAR,ros_A((istage-1)*(istage-2)/2+j), &
-                K(NVAR*(j-1)+1,iadj),1,Ynew(1,iadj),1) 
-           END DO       
+                K(NVAR*(j-1)+1,iadj),1,Ynew(1,iadj),1)
+           END DO
          END DO
          Tau = T + ros_Alpha(istage)*Direction*H
          CALL ros_Hermite3( chk_T(istack-1), chk_T(istack), Tau, &
              chk_Y(1:NVAR,istack-1), chk_Y(1:NVAR,istack),       &
              chk_dY(1:NVAR,istack-1), chk_dY(1:NVAR,istack), Y0 )
-         CALL JacTemplate(Tau, Y0, Jac)
+         CALL JacTemplate( Tau, Y0, Jac )
          ISTATUS(Njac) = ISTATUS(Njac) + 1
 #ifdef FULL_ALGEBRA
          Jac(1:NVAR,1:NVAR) = -Jac(1:NVAR,1:NVAR)
@@ -1697,40 +1717,40 @@ Stage: DO istage = 1, ros_S
        DO iadj = 1, NADJ
          CALL ros_Solve('T', Ghimj, Pivot, K(ioffset+1,iadj))
        END DO
-      
-   END DO Stage     
-            
 
-!~~~>  Compute the new solution 
+   END DO Stage
+
+
+!~~~>  Compute the new solution
    DO iadj = 1, NADJ
       DO j=1,ros_S
          CALL WAXPY(NVAR,ros_M(j),K(NVAR*(j-1)+1,iadj),1,Y(1,iadj),1)
       END DO
    END DO
 
-   END DO TimeLoop 
-      
+   END DO TimeLoop
+
 !~~~> Succesful exit
    IERR = 1  !~~~> The integration was successful
 
   END SUBROUTINE ros_SimpleCadjInt
-  
+
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  KPP_REAL FUNCTION ros_ErrorNorm ( Y, Ynew, Yerr, & 
+  KPP_REAL FUNCTION ros_ErrorNorm ( Y, Ynew, Yerr, &
                AbsTol, RelTol, VectorTol )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !~~~> Computes the "scaled norm" of the error vector Yerr
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   IMPLICIT NONE         
+   IMPLICIT NONE
 
-! Input arguments   
+! Input arguments
    KPP_REAL, INTENT(IN) :: Y(NVAR), Ynew(NVAR), &
           Yerr(NVAR), AbsTol(NVAR), RelTol(NVAR)
    LOGICAL, INTENT(IN) ::  VectorTol
-! Local variables     
-   KPP_REAL :: Err, Scale, Ymax   
+! Local variables
+   KPP_REAL :: Err, Scale, Ymax
    INTEGER  :: i
-   
+
    Err = ZERO
    DO i=1,NVAR
      Ymax = MAX(ABS(Y(i)),ABS(Ynew(i)))
@@ -1744,7 +1764,7 @@ Stage: DO istage = 1, ros_S
    Err  = SQRT(Err/NVAR)
 
    ros_ErrorNorm = MAX(Err,1.0d-10)
-   
+
   END FUNCTION ros_ErrorNorm
 
 
@@ -1753,18 +1773,18 @@ Stage: DO istage = 1, ros_S
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !~~~> The time partial derivative of the function by finite differences
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   IMPLICIT NONE         
+   IMPLICIT NONE
 
-!~~~> Input arguments   
-   KPP_REAL, INTENT(IN) :: T, Roundoff, Y(NVAR), Fcn0(NVAR) 
-!~~~> Output arguments   
-   KPP_REAL, INTENT(OUT) :: dFdT(NVAR)   
-!~~~> Local variables     
-   KPP_REAL :: Delta  
+!~~~> Input arguments
+   KPP_REAL, INTENT(IN) :: T, Roundoff, Y(NVAR), Fcn0(NVAR)
+!~~~> Output arguments
+   KPP_REAL, INTENT(OUT) :: dFdT(NVAR)
+!~~~> Local variables
+   KPP_REAL :: Delta
    KPP_REAL, PARAMETER :: ONE = 1.0d0, DeltaMin = 1.0d-6
-   
+
    Delta = SQRT(Roundoff)*MAX(DeltaMin,ABS(T))
-   CALL FunTemplate(T+Delta,Y,dFdT)
+   CALL FunTemplate( T+Delta, Y, dFdT )
    ISTATUS(Nfun) = ISTATUS(Nfun) + 1
    CALL WAXPY(NVAR,(-ONE),Fcn0,1,dFdT,1)
    CALL WSCAL(NVAR,(ONE/Delta),dFdT,1)
@@ -1773,35 +1793,34 @@ Stage: DO istage = 1, ros_S
 
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  SUBROUTINE ros_JacTimeDerivative ( T, Roundoff, Y, &
-                Jac0, dJdT )
+  SUBROUTINE ros_JacTimeDerivative ( T, Roundoff, Y, Jac0, dJdT )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !~~~> The time partial derivative of the Jacobian by finite differences
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   IMPLICIT NONE         
+   IMPLICIT NONE
 
-!~~~> Arguments   
+!~~~> Arguments
    KPP_REAL, INTENT(IN) :: T, Roundoff, Y(NVAR)
-#ifdef FULL_ALGEBRA    
-   KPP_REAL, INTENT(IN)  :: Jac0(NVAR,NVAR) 
-   KPP_REAL, INTENT(OUT) :: dJdT(NVAR,NVAR)   
+#ifdef FULL_ALGEBRA
+   KPP_REAL, INTENT(IN)  :: Jac0(NVAR,NVAR)
+   KPP_REAL, INTENT(OUT) :: dJdT(NVAR,NVAR)
 #else
-   KPP_REAL, INTENT(IN)  :: Jac0(LU_NONZERO) 
-   KPP_REAL, INTENT(OUT) :: dJdT(LU_NONZERO)   
-#endif   
-!~~~> Local variables     
-   KPP_REAL :: Delta  
-   
+   KPP_REAL, INTENT(IN)  :: Jac0(LU_NONZERO)
+   KPP_REAL, INTENT(OUT) :: dJdT(LU_NONZERO)
+#endif
+!~~~> Local variables
+   KPP_REAL :: Delta
+
    Delta = SQRT(Roundoff)*MAX(DeltaMin,ABS(T))
-   CALL JacTemplate(T+Delta,Y,dJdT)
+   CALL JacTemplate( T+Delta, Y, dJdT )
    ISTATUS(Njac) = ISTATUS(Njac) + 1
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
    CALL WAXPY(NVAR*NVAR,(-ONE),Jac0,1,dJdT,1)
    CALL WSCAL(NVAR*NVAR,(ONE/Delta),dJdT,1)
 #else
    CALL WAXPY(LU_NONZERO,(-ONE),Jac0,1,dJdT,1)
    CALL WSCAL(LU_NONZERO,(ONE/Delta),dJdT,1)
-#endif   
+#endif
 
   END SUBROUTINE ros_JacTimeDerivative
 
@@ -1821,19 +1840,19 @@ Stage: DO istage = 1, ros_S
    IMPLICIT NONE
 
 !~~~> Input arguments
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
    KPP_REAL, INTENT(IN) ::  Jac0(NVAR,NVAR)
 #else
    KPP_REAL, INTENT(IN) ::  Jac0(LU_NONZERO)
-#endif   
+#endif
    KPP_REAL, INTENT(IN) ::  gam
    INTEGER, INTENT(IN) ::  Direction
 !~~~> Output arguments
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
    KPP_REAL, INTENT(OUT) :: Ghimj(NVAR,NVAR)
 #else
    KPP_REAL, INTENT(OUT) :: Ghimj(LU_NONZERO)
-#endif   
+#endif
    LOGICAL, INTENT(OUT) ::  Singular
    INTEGER, INTENT(OUT) ::  Pivot(NVAR)
 !~~~> Inout arguments
@@ -1849,7 +1868,7 @@ Stage: DO istage = 1, ros_S
    DO WHILE (Singular)
 
 !~~~>    Construct Ghimj = 1/(H*gam) - Jac0
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
      CALL WCOPY(NVAR*NVAR,Jac0,1,Ghimj,1)
      CALL WSCAL(NVAR*NVAR,(-ONE),Ghimj,1)
      ghinv = ONE/(Direction*H*gam)
@@ -1863,7 +1882,7 @@ Stage: DO istage = 1, ros_S
      DO i=1,NVAR
        Ghimj(LU_DIAG(i)) = Ghimj(LU_DIAG(i))+ghinv
      END DO
-#endif   
+#endif
 !~~~>    Compute LU decomposition
      CALL ros_Decomp( Ghimj, Pivot, ISING )
      IF (ISING == 0) THEN
@@ -1894,17 +1913,17 @@ Stage: DO istage = 1, ros_S
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    IMPLICIT NONE
 !~~~> Inout variables
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
    KPP_REAL, INTENT(INOUT) :: A(NVAR,NVAR)
-#else   
+#else
    KPP_REAL, INTENT(INOUT) :: A(LU_NONZERO)
 #endif
 !~~~> Output variables
    INTEGER, INTENT(OUT) :: Pivot(NVAR), ISING
 
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
    CALL  DGETRF( NVAR, NVAR, A, NVAR, Pivot, ISING )
-#else   
+#else
    CALL KppDecomp ( A, ISING )
    Pivot(1) = 1
 #endif
@@ -1921,10 +1940,10 @@ Stage: DO istage = 1, ros_S
    IMPLICIT NONE
 !~~~> Input variables
    CHARACTER, INTENT(IN) :: How
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
    KPP_REAL, INTENT(IN) :: A(NVAR,NVAR)
    INTEGER :: ISING
-#else   
+#else
    KPP_REAL, INTENT(IN) :: A(LU_NONZERO)
 #endif
    INTEGER, INTENT(IN) :: Pivot(NVAR)
@@ -1933,15 +1952,15 @@ Stage: DO istage = 1, ros_S
 
    SELECT CASE (How)
    CASE ('N')
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
      CALL DGETRS( 'N', NVAR , 1, A, NVAR, Pivot, b, NVAR, ISING )
-#else   
+#else
      CALL KppSolve( A, b )
 #endif
    CASE ('T')
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
      CALL DGETRS( 'T', NVAR , 1, A, NVAR, Pivot, b, NVAR, ISING )
-#else   
+#else
      CALL KppSolveTR( A, b, b )
 #endif
    CASE DEFAULT
@@ -1952,19 +1971,19 @@ Stage: DO istage = 1, ros_S
 
   END SUBROUTINE ros_Solve
 
-  
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE ros_cadj_Y( T, Y )
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !  Finds the solution Y at T by interpolating the stored forward trajectory
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    IMPLICIT NONE
-!~~~> Input variables 
+!~~~> Input variables
    KPP_REAL, INTENT(IN) :: T
-!~~~> Output variables     
+!~~~> Output variables
    KPP_REAL, INTENT(OUT) :: Y(NVAR)
-!~~~> Local variables     
+!~~~> Local variables
    INTEGER     :: i
    KPP_REAL, PARAMETER  :: ONE = 1.0d0
 
@@ -1978,7 +1997,7 @@ Stage: DO istage = 1, ros_S
    END IF
    DO i = 1, stack_ptr-1
      IF( (T>= chk_T(i)).AND.(T<= chk_T(i+1)) ) EXIT
-   END DO 
+   END DO
 
 
 !   IF (.FALSE.) THEN
@@ -1987,44 +2006,44 @@ Stage: DO istage = 1, ros_S
 !                chk_Y(1,i),   chk_Y(1,i+1),     &
 !                chk_dY(1,i),  chk_dY(1,i+1),    &
 !                chk_d2Y(1,i), chk_d2Y(1,i+1), Y )
-!   
+!
 !   ELSE
-                
+
    CALL ros_Hermite3( chk_T(i), chk_T(i+1), T, &
                 chk_Y(1:NVAR,i),   chk_Y(1:NVAR,i+1),     &
                 chk_dY(1:NVAR,i),  chk_dY(1:NVAR,i+1),    &
                 Y )
-                        
-!   
-!   END IF       
+
+!
+!   END IF
 
   END SUBROUTINE ros_cadj_Y
-  
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE ros_Hermite3( a, b, T, Ya, Yb, Ja, Jb, Y )
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !  Template for Hermite interpolation of order 5 on the interval [a,b]
 ! P = c(1) + c(2)*(x-a) + ... + c(4)*(x-a)^3
 ! P[a,b] = [Ya,Yb], P'[a,b] = [Ja,Jb]
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    IMPLICIT NONE
-!~~~> Input variables 
+!~~~> Input variables
    KPP_REAL, INTENT(IN) :: a, b, T, Ya(NVAR), Yb(NVAR)
    KPP_REAL, INTENT(IN) :: Ja(NVAR), Jb(NVAR)
-!~~~> Output variables     
+!~~~> Output variables
    KPP_REAL, INTENT(OUT) :: Y(NVAR)
-!~~~> Local variables     
+!~~~> Local variables
    KPP_REAL :: Tau, amb(3), C(NVAR,4)
    KPP_REAL, PARAMETER :: ZERO = 0.0d0
    INTEGER :: i, j
-   
+
    amb(1) = 1.0d0/(a-b)
    DO i=2,3
      amb(i) = amb(i-1)*amb(1)
    END DO
-   
-   
+
+
 ! c(1) = ya;
    CALL WCOPY(NVAR,Ya,1,C(1,1),1)
 ! c(2) = ja;
@@ -2041,39 +2060,39 @@ Stage: DO istage = 1, ros_S
    CALL WAXPY(NVAR,2.0*amb(3),Yb,1,C(1,4),1)
    CALL WAXPY(NVAR,amb(2),Ja,1,C(1,4),1)
    CALL WAXPY(NVAR,amb(2),Jb,1,C(1,4),1)
-   
+
    Tau = T - a
    CALL WCOPY(NVAR,C(1,4),1,Y,1)
    CALL WSCAL(NVAR,Tau**3,Y,1)
    DO j = 3,1,-1
      CALL WAXPY(NVAR,TAU**(j-1),C(1,j),1,Y,1)
-   END DO       
+   END DO
 
   END SUBROUTINE ros_Hermite3
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE ros_Hermite5( a, b, T, Ya, Yb, Ja, Jb, Ha, Hb, Y )
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !  Template for Hermite interpolation of order 5 on the interval [a,b]
 ! P = c(1) + c(2)*(x-a) + ... + c(6)*(x-a)^5
 ! P[a,b] = [Ya,Yb], P'[a,b] = [Ja,Jb], P"[a,b] = [Ha,Hb]
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    IMPLICIT NONE
-!~~~> Input variables 
+!~~~> Input variables
    KPP_REAL, INTENT(IN) :: a, b, T, Ya(NVAR), Yb(NVAR)
    KPP_REAL, INTENT(IN) :: Ja(NVAR), Jb(NVAR), Ha(NVAR), Hb(NVAR)
-!~~~> Output variables     
+!~~~> Output variables
    KPP_REAL, INTENT(OUT) :: Y(NVAR)
-!~~~> Local variables     
+!~~~> Local variables
    KPP_REAL :: Tau, amb(5), C(NVAR,6)
    KPP_REAL, PARAMETER :: ZERO = 0.0d0, HALF = 0.5d0
    INTEGER :: i, j
-   
+
    amb(1) = 1.0d0/(a-b)
    DO i=2,5
      amb(i) = amb(i-1)*amb(1)
    END DO
-     
+
 ! c(1) = ya;
    CALL WCOPY(NVAR,Ya,1,C(1,1),1)
 ! c(2) = ja;
@@ -2081,7 +2100,7 @@ Stage: DO istage = 1, ros_S
 ! c(3) = ha/2;
    CALL WCOPY(NVAR,Ha,1,C(1,3),1)
    CALL WSCAL(NVAR,HALF,C(1,3),1)
-   
+
 ! c(4) = 10*amb(3)*ya - 10*amb(3)*yb - 6*amb(2)*ja - 4*amb(2)*jb  + 1.5*amb(1)*ha - 0.5*amb(1)*hb ;
    CALL WCOPY(NVAR,Ya,1,C(1,4),1)
    CALL WSCAL(NVAR,10.0*amb(3),C(1,4),1)
@@ -2099,7 +2118,7 @@ Stage: DO istage = 1, ros_S
    CALL WAXPY(NVAR,-7.0*amb(3),Jb,1,C(1,5),1)
    CALL WAXPY(NVAR,1.5*amb(2),Ha,1,C(1,5),1)
    CALL WAXPY(NVAR,-amb(2),Hb,1,C(1,5),1)
-   
+
 ! c(6) =   6*amb(5)*ya - 6*amb(5)*yb - 3.*amb(4)*ja - 3.*amb(4)*jb + 0.5*amb(3)*ha -0.5*amb(3)*hb ;
    CALL WCOPY(NVAR,Ya,1,C(1,6),1)
    CALL WSCAL(NVAR, 6.0*amb(5),C(1,6),1)
@@ -2108,40 +2127,40 @@ Stage: DO istage = 1, ros_S
    CALL WAXPY(NVAR,-3.0*amb(4),Jb,1,C(1,6),1)
    CALL WAXPY(NVAR, 0.5*amb(3),Ha,1,C(1,6),1)
    CALL WAXPY(NVAR,-0.5*amb(3),Hb,1,C(1,6),1)
-   
+
    Tau = T - a
    CALL WCOPY(NVAR,C(1,6),1,Y,1)
    DO j = 5,1,-1
      CALL WSCAL(NVAR,Tau,Y,1)
      CALL WAXPY(NVAR,ONE,C(1,j),1,Y,1)
-   END DO       
+   END DO
 
   END SUBROUTINE ros_Hermite5
- 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE Ros2
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ! --- AN L-STABLE METHOD, 2 stages, order 2
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     IMPLICIT NONE
     DOUBLE PRECISION g
-   
+
     g = 1.0d0 + 1.0d0/SQRT(2.0d0)
-   
+
     rosMethod = RS2
 !~~~> Name of the method
-    ros_Name = 'ROS-2'   
+    ros_Name = 'ROS-2'
 !~~~> Number of stages
     ros_S = 2
-   
+
 !~~~> The coefficient matrices A and C are strictly lower triangular.
 !   The lower triangular (subdiagonal) elements are stored in row-wise order:
 !   A(2,1) = ros_A(1), A(3,1)=ros_A(2), A(3,2)=ros_A(3), etc.
 !   The general mapping formula is:
-!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )    
-!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )  
-   
+!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )
+!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )
+
     ros_A(1) = (1.d0)/g
     ros_C(1) = (-2.d0)/g
 !~~~> Does the stage i require a new function evaluation (ros_NewF(i)=TRUE)
@@ -2151,43 +2170,43 @@ Stage: DO istage = 1, ros_S
 !~~~> M_i = Coefficients for new step solution
     ros_M(1)= (3.d0)/(2.d0*g)
     ros_M(2)= (1.d0)/(2.d0*g)
-! E_i = Coefficients for error estimator    
+! E_i = Coefficients for error estimator
     ros_E(1) = 1.d0/(2.d0*g)
     ros_E(2) = 1.d0/(2.d0*g)
 !~~~> ros_ELO = estimator of local order - the minimum between the
 !    main and the embedded scheme orders plus one
-    ros_ELO = 2.0d0    
+    ros_ELO = 2.0d0
 !~~~> Y_stage_i ~ Y( T + H*Alpha_i )
     ros_Alpha(1) = 0.0d0
-    ros_Alpha(2) = 1.0d0 
-!~~~> Gamma_i = \sum_j  gamma_{i,j}    
+    ros_Alpha(2) = 1.0d0
+!~~~> Gamma_i = \sum_j  gamma_{i,j}
     ros_Gamma(1) = g
     ros_Gamma(2) =-g
-   
+
  END SUBROUTINE Ros2
 
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE Ros3
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ! --- AN L-STABLE METHOD, 3 stages, order 3, 2 function evaluations
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
-  
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
    IMPLICIT NONE
-    
+
     rosMethod = RS3
 !~~~> Name of the method
-   ros_Name = 'ROS-3'   
+   ros_Name = 'ROS-3'
 !~~~> Number of stages
    ros_S = 3
-   
+
 !~~~> The coefficient matrices A and C are strictly lower triangular.
 !   The lower triangular (subdiagonal) elements are stored in row-wise order:
 !   A(2,1) = ros_A(1), A(3,1)=ros_A(2), A(3,2)=ros_A(3), etc.
 !   The general mapping formula is:
-!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )    
-!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )  
-     
+!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )
+!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )
+
    ros_A(1)= 1.d0
    ros_A(2)= 1.d0
    ros_A(3)= 0.d0
@@ -2204,54 +2223,54 @@ Stage: DO istage = 1, ros_S
    ros_M(1) =  0.1d+01
    ros_M(2) =  0.61697947043828245592553615689730d+01
    ros_M(3) = -0.42772256543218573326238373806514d+00
-! E_i = Coefficients for error estimator    
+! E_i = Coefficients for error estimator
    ros_E(1) =  0.5d+00
    ros_E(2) = -0.29079558716805469821718236208017d+01
    ros_E(3) =  0.22354069897811569627360909276199d+00
 !~~~> ros_ELO = estimator of local order - the minimum between the
 !    main and the embedded scheme orders plus 1
-   ros_ELO = 3.0d0    
+   ros_ELO = 3.0d0
 !~~~> Y_stage_i ~ Y( T + H*Alpha_i )
    ros_Alpha(1)= 0.0d+00
    ros_Alpha(2)= 0.43586652150845899941601945119356d+00
    ros_Alpha(3)= 0.43586652150845899941601945119356d+00
-!~~~> Gamma_i = \sum_j  gamma_{i,j}    
+!~~~> Gamma_i = \sum_j  gamma_{i,j}
    ros_Gamma(1)= 0.43586652150845899941601945119356d+00
    ros_Gamma(2)= 0.24291996454816804366592249683314d+00
    ros_Gamma(3)= 0.21851380027664058511513169485832d+01
 
   END SUBROUTINE Ros3
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE Ros4
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !     L-STABLE ROSENBROCK METHOD OF ORDER 4, WITH 4 STAGES
-!     L-STABLE EMBEDDED ROSENBROCK METHOD OF ORDER 3 
+!     L-STABLE EMBEDDED ROSENBROCK METHOD OF ORDER 3
 !
 !      E. HAIRER AND G. WANNER, SOLVING ORDINARY DIFFERENTIAL
 !      EQUATIONS II. STIFF AND DIFFERENTIAL-ALGEBRAIC PROBLEMS.
 !      SPRINGER SERIES IN COMPUTATIONAL MATHEMATICS,
-!      SPRINGER-VERLAG (1990)         
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!      SPRINGER-VERLAG (1990)
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
    IMPLICIT NONE
-   
+
     rosMethod = RS4
 !~~~> Name of the method
-   ros_Name = 'ROS-4'   
+   ros_Name = 'ROS-4'
 !~~~> Number of stages
    ros_S = 4
-   
+
 !~~~> The coefficient matrices A and C are strictly lower triangular.
 !   The lower triangular (subdiagonal) elements are stored in row-wise order:
 !   A(2,1) = ros_A(1), A(3,1)=ros_A(2), A(3,2)=ros_A(3), etc.
 !   The general mapping formula is:
-!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )    
-!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )  
-     
+!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )
+!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )
+
    ros_A(1) = 0.2000000000000000d+01
    ros_A(2) = 0.1867943637803922d+01
    ros_A(3) = 0.2344449711399156d+00
@@ -2276,48 +2295,48 @@ Stage: DO istage = 1, ros_S
    ros_M(2) = 0.2870493262186792d+00
    ros_M(3) = 0.4353179431840180d+00
    ros_M(4) = 0.1093502252409163d+01
-!~~~> E_i  = Coefficients for error estimator    
+!~~~> E_i  = Coefficients for error estimator
    ros_E(1) =-0.2815431932141155d+00
    ros_E(2) =-0.7276199124938920d-01
    ros_E(3) =-0.1082196201495311d+00
    ros_E(4) =-0.1093502252409163d+01
 !~~~> ros_ELO  = estimator of local order - the minimum between the
 !    main and the embedded scheme orders plus 1
-   ros_ELO  = 4.0d0    
+   ros_ELO  = 4.0d0
 !~~~> Y_stage_i ~ Y( T + H*Alpha_i )
    ros_Alpha(1) = 0.D0
    ros_Alpha(2) = 0.1145640000000000d+01
    ros_Alpha(3) = 0.6552168638155900d+00
    ros_Alpha(4) = ros_Alpha(3)
-!~~~> Gamma_i = \sum_j  gamma_{i,j}    
+!~~~> Gamma_i = \sum_j  gamma_{i,j}
    ros_Gamma(1) = 0.5728200000000000d+00
    ros_Gamma(2) =-0.1769193891319233d+01
    ros_Gamma(3) = 0.7592633437920482d+00
    ros_Gamma(4) =-0.1049021087100450d+00
 
   END SUBROUTINE Ros4
-   
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE Rodas3
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ! --- A STIFFLY-STABLE METHOD, 4 stages, order 3
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
    IMPLICIT NONE
-   
+
     rosMethod = RD3
 !~~~> Name of the method
-   ros_Name = 'RODAS-3'   
+   ros_Name = 'RODAS-3'
 !~~~> Number of stages
    ros_S = 4
-   
+
 !~~~> The coefficient matrices A and C are strictly lower triangular.
 !   The lower triangular (subdiagonal) elements are stored in row-wise order:
 !   A(2,1) = ros_A(1), A(3,1)=ros_A(2), A(3,2)=ros_A(3), etc.
 !   The general mapping formula is:
-!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )    
-!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )  
- 
+!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )
+!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )
+
    ros_A(1) = 0.0d+00
    ros_A(2) = 2.0d+00
    ros_A(3) = 0.0d+00
@@ -2329,9 +2348,9 @@ Stage: DO istage = 1, ros_S
    ros_C(2) = 1.0d+00
    ros_C(3) =-1.0d+00
    ros_C(4) = 1.0d+00
-   ros_C(5) =-1.0d+00 
-   ros_C(6) =-(8.0d+00/3.0d+00) 
-         
+   ros_C(5) =-1.0d+00
+   ros_C(6) =-(8.0d+00/3.0d+00)
+
 !~~~> Does the stage i require a new function evaluation (ros_NewF(i)=TRUE)
 !   or does it re-use the function evaluation from stage i-1 (ros_NewF(i)=FALSE)
    ros_NewF(1)  = .TRUE.
@@ -2343,55 +2362,55 @@ Stage: DO istage = 1, ros_S
    ros_M(2) = 0.0d+00
    ros_M(3) = 1.0d+00
    ros_M(4) = 1.0d+00
-!~~~> E_i  = Coefficients for error estimator    
+!~~~> E_i  = Coefficients for error estimator
    ros_E(1) = 0.0d+00
    ros_E(2) = 0.0d+00
    ros_E(3) = 0.0d+00
    ros_E(4) = 1.0d+00
 !~~~> ros_ELO  = estimator of local order - the minimum between the
 !    main and the embedded scheme orders plus 1
-   ros_ELO  = 3.0d+00    
+   ros_ELO  = 3.0d+00
 !~~~> Y_stage_i ~ Y( T + H*Alpha_i )
    ros_Alpha(1) = 0.0d+00
    ros_Alpha(2) = 0.0d+00
    ros_Alpha(3) = 1.0d+00
    ros_Alpha(4) = 1.0d+00
-!~~~> Gamma_i = \sum_j  gamma_{i,j}    
+!~~~> Gamma_i = \sum_j  gamma_{i,j}
    ros_Gamma(1) = 0.5d+00
    ros_Gamma(2) = 1.5d+00
    ros_Gamma(3) = 0.0d+00
    ros_Gamma(4) = 0.0d+00
 
   END SUBROUTINE Rodas3
-    
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE Rodas4
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !     STIFFLY-STABLE ROSENBROCK METHOD OF ORDER 4, WITH 6 STAGES
 !
 !      E. HAIRER AND G. WANNER, SOLVING ORDINARY DIFFERENTIAL
 !      EQUATIONS II. STIFF AND DIFFERENTIAL-ALGEBRAIC PROBLEMS.
 !      SPRINGER SERIES IN COMPUTATIONAL MATHEMATICS,
-!      SPRINGER-VERLAG (1996)         
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!      SPRINGER-VERLAG (1996)
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
    IMPLICIT NONE
 
     rosMethod = RD4
 !~~~> Name of the method
-    ros_Name = 'RODAS-4'   
+    ros_Name = 'RODAS-4'
 !~~~> Number of stages
     ros_S = 6
 
 !~~~> Y_stage_i ~ Y( T + H*Alpha_i )
     ros_Alpha(1) = 0.000d0
     ros_Alpha(2) = 0.386d0
-    ros_Alpha(3) = 0.210d0 
+    ros_Alpha(3) = 0.210d0
     ros_Alpha(4) = 0.630d0
     ros_Alpha(5) = 1.000d0
     ros_Alpha(6) = 1.000d0
-        
-!~~~> Gamma_i = \sum_j  gamma_{i,j}    
+
+!~~~> Gamma_i = \sum_j  gamma_{i,j}
     ros_Gamma(1) = 0.2500000000000000d+00
     ros_Gamma(2) =-0.1043000000000000d+00
     ros_Gamma(3) = 0.1035000000000000d+00
@@ -2402,9 +2421,9 @@ Stage: DO istage = 1, ros_S
 !~~~> The coefficient matrices A and C are strictly lower triangular.
 !   The lower triangular (subdiagonal) elements are stored in row-wise order:
 !   A(2,1) = ros_A(1), A(3,1)=ros_A(2), A(3,2)=ros_A(3), etc.
-!   The general mapping formula is:  A(i,j) = ros_A( (i-1)*(i-2)/2 + j )    
-!                  C(i,j) = ros_C( (i-1)*(i-2)/2 + j )  
-     
+!   The general mapping formula is:  A(i,j) = ros_A( (i-1)*(i-2)/2 + j )
+!                  C(i,j) = ros_C( (i-1)*(i-2)/2 + j )
+
     ros_A(1) = 0.1544000000000000d+01
     ros_A(2) = 0.9466785280815826d+00
     ros_A(3) = 0.2557011698983284d+00
@@ -2445,7 +2464,7 @@ Stage: DO istage = 1, ros_S
     ros_M(5) = 1.0d+00
     ros_M(6) = 1.0d+00
 
-!~~~> E_i  = Coefficients for error estimator    
+!~~~> E_i  = Coefficients for error estimator
     ros_E(1) = 0.0d+00
     ros_E(2) = 0.0d+00
     ros_E(3) = 0.0d+00
@@ -2461,38 +2480,38 @@ Stage: DO istage = 1, ros_S
     ros_NewF(4) = .TRUE.
     ros_NewF(5) = .TRUE.
     ros_NewF(6) = .TRUE.
-     
+
 !~~~> ros_ELO  = estimator of local order - the minimum between the
 !        main and the embedded scheme orders plus 1
     ros_ELO = 4.0d0
-     
+
   END SUBROUTINE Rodas4
 
 
 END SUBROUTINE RosenbrockADJ ! and its internal procedures
-  
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 SUBROUTINE FunTemplate( T, Y, Ydot )
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !  Template for the ODE function call.
-!  Updates the rate coefficients (and possibly the fixed species) at each call    
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
- 
-!~~~> Input variables     
+!  Updates the rate coefficients (and possibly the fixed species) at each call
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+!~~~> Input variables
    KPP_REAL, INTENT(IN)  :: T, Y(NVAR)
-!~~~> Output variables     
+!~~~> Output variables
    KPP_REAL, INTENT(OUT) :: Ydot(NVAR)
 !~~~> Local variables
-   KPP_REAL :: Told     
+   KPP_REAL :: Told
 
    Told = TIME
    TIME = T
-   CALL Update_SUN()
-   CALL Update_RCONST()
+   IF ( Do_Update_SUN    ) CALL Update_SUN()
+   IF ( Do_Update_RCONST ) CALL Update_RCONST()
    CALL Fun( Y, FIX, RCONST, Ydot )
    TIME = Told
-   
+
 END SUBROUTINE FunTemplate
 
 
@@ -2506,22 +2525,22 @@ SUBROUTINE JacTemplate( T, Y, Jcb )
 !~~~> Input variables
     KPP_REAL :: T, Y(NVAR)
 !~~~> Output variables
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
     KPP_REAL :: JV(LU_NONZERO), Jcb(NVAR,NVAR)
 #else
     KPP_REAL :: Jcb(LU_NONZERO)
-#endif   
+#endif
 !~~~> Local variables
     KPP_REAL :: Told
-#ifdef FULL_ALGEBRA    
+#ifdef FULL_ALGEBRA
     INTEGER :: i, j
-#endif   
+#endif
 
     Told = TIME
     TIME = T
-    CALL Update_SUN()
-    CALL Update_RCONST()
-#ifdef FULL_ALGEBRA    
+    IF ( Do_Update_SUN    ) CALL Update_SUN()
+    IF ( Do_Update_RCONST ) CALL Update_RCONST()
+#ifdef FULL_ALGEBRA
     CALL Jac_SP(Y, FIX, RCONST, JV)
     DO j=1,NVAR
       DO i=1,NVAR
@@ -2533,38 +2552,72 @@ SUBROUTINE JacTemplate( T, Y, Jcb )
     END DO
 #else
     CALL Jac_SP( Y, FIX, RCONST, Jcb )
-#endif   
+#endif
     TIME = Told
 
 END SUBROUTINE JacTemplate
 
 
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 SUBROUTINE HessTemplate( T, Y, Hes )
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !  Template for the ODE Hessian call.
-!  Updates the rate coefficients (and possibly the fixed species) at each call    
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!  Updates the rate coefficients (and possibly the fixed species) at each call
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-!~~~> Input variables     
+!~~~> Input variables
     KPP_REAL, INTENT(IN)  :: T, Y(NVAR)
-!~~~> Output variables     
+!~~~> Output variables
     KPP_REAL, INTENT(OUT) :: Hes(NHESS)
 !~~~> Local variables
-    KPP_REAL :: Told     
+    KPP_REAL :: Told
 
     Told = TIME
-    TIME = T   
-    CALL Update_SUN()
-    CALL Update_RCONST()
+    TIME = T
+    IF ( Do_Update_SUN    ) CALL Update_SUN()
+    IF ( Do_Update_RCONST ) CALL Update_RCONST()
     CALL Hessian( Y, FIX, RCONST, Hes )
     TIME = Told
 
-END SUBROUTINE HessTemplate                                      
+END SUBROUTINE HessTemplate
+
+SUBROUTINE Integrator_Update_Options( option )
+
+!    option      -> determine whether to call Update_RCONST, Update_PHOTO,
+!                   and Update_SUN from within the integrator
+!        = -1 :   Do not call Update_* functions within the integrator
+!        =  0 :   Status quo: Call whichever functions are normally called
+!        =  1 :   Call Update_RCONST from within the integrator
+!        =  2 :   Call Update_PHOTO from within the integrator
+!        =  3 :   Call Update_RCONST and Update_PHOTO from within the int.
+!        =  4 :   Call Update_SUN from within the integrator
+!        =  5 :   Call Update_SUN and Update_RCONST from within the int.
+
+!~~~> Input variable
+  INTEGER, INTENT(IN) :: option
+
+  ! Option -1: turn off all Update_* calls within the integrator
+  IF ( option == -1 ) THEN
+     Do_Update_RCONST = .FALSE.
+     Do_Update_PHOTO  = .FALSE.
+     Do_Update_SUN    = .FALSE.
+     RETURN
+  ENDIF
+
+  ! Option 0: status quo: Call update functions if defined
+  IF ( option == 0 ) THEN
+     Do_Update_RCONST = .TRUE.
+     Do_Update_PHOTO  = .TRUE.
+     Do_Update_SUN    = .TRUE.
+     RETURN
+  ENDIF
+
+  ! Otherwise determine from the value passed
+  Do_Update_RCONST = ( IAND( option, 1 ) > 0 )
+  Do_Update_PHOTO  = ( IAND( option, 2 ) > 0 )
+  Do_Update_SUN    = ( IAND( option, 4 ) > 0 )
+
+END SUBROUTINE Integrator_Update_Options
 
 END MODULE KPP_ROOT_Integrator
-
-
-
-

--- a/int/rosenbrock_split.f90
+++ b/int/rosenbrock_split.f90
@@ -19,10 +19,18 @@ MODULE KPP_ROOT_Integrator
 
   USE KPP_ROOT_Parameters, ONLY: NVAR, NFIX, NSPEC, LU_NONZERO
   USE KPP_ROOT_Global
+
   IMPLICIT NONE
   PUBLIC
   SAVE
   
+!~~~> Flags to determine if we should call the UPDATE_* routines from within 
+!~~~> the integrator.  If using KPP in an external model, you might want to
+!~~~> disable these calls (via ICNTRL(15)) to avoid excess computations.
+  LOGICAL :: Do_Update_RCONST
+  LOGICAL :: Do_Update_PHOTO
+  LOGICAL :: Do_Update_SUN
+
 !~~~>  Statistics on the work performed by the Rosenbrock method
   INTEGER, PARAMETER :: Nfun=1, Njac=2, Nstp=3, Nacc=4, &
                         Nrej=5, Ndec=6, Nsol=7, Nsng=8, &
@@ -32,6 +40,8 @@ CONTAINS
 
 SUBROUTINE INTEGRATE( TIN, TOUT, &
   ICNTRL_U, RCNTRL_U, ISTATUS_U, RSTATUS_U, IERR_U )
+
+   USE KPP_ROOT_Util, ONLY : Integrator_Update_Options
 
    IMPLICIT NONE
 
@@ -67,7 +77,24 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
      WHERE(RCNTRL_U(:) > 0) RCNTRL(:) = RCNTRL_U(:)
    END IF
 
+   ! Determine the settings of the Do_Update_* flags, which determine
+   ! whether or not we need to call Update_* routines in the integrator
+   ! (or not, if we are calling them from a higher-level)
+   ! ICNTRL(15) = -1 ! Do not call Update_* functions within the integrator
+   !            =  0 ! Status quo
+   !            =  1 ! Call Update_RCONST from within the integrator
+   !            =  2 ! Call Update_PHOTO from within the integrator
+   !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
+   !            =  4 ! Call Update_SUN from within the integrator
+   !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
+   !            =  6 ! Not implemented
+   !            =  7 ! Not implemented
+   CALL Integrator_Update_Options( ICNTRL(15),          &
+                                   Do_Update_RCONST,    &
+                                   Do_Update_PHOTO,     &
+                                   Do_Update_Sun       )
 
+   ! Call the integrator
    CALL Rosenbrock(NVAR,VAR,TIN,TOUT,   &
          ATOL,RTOL,                &
          RCNTRL,ICNTRL,RSTATUS,ISTATUS,IERR)
@@ -158,6 +185,17 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
 !
 !    ICNTRL(4)  -> maximum number of integration steps
 !        For ICNTRL(4)=0) the default value of 100000 is used
+!
+!    ICNTRL(15) -> Toggles calling of Update_* functions w/in the integrator
+!        = -1 :  Do not call Update_* functions within the integrator
+!        =  0 :  Status quo
+!        =  1 :  Call Update_RCONST from within the integrator
+!        =  2 :  Call Update_PHOTO from within the integrator
+!        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
+!        =  4 :  Call Update_SUN from within the integrator
+!        =  5 :  Call Update_SUN and Update_RCONST from within the int.
+!        =  6 :  Not implemented
+!        =  7 :  Not implemented
 !
 !    RCNTRL(1)  -> Hmin, lower bound for the integration step size
 !          It is strongly recommended to keep Hmin = ZERO
@@ -1270,8 +1308,8 @@ SUBROUTINE FunSplitTemplate( T, Y, Ydot, P_VAR, D_VAR )
 
    Told = TIME
    TIME = T
-   CALL Update_SUN()
-   CALL Update_RCONST()
+   IF ( Do_Update_SUN    ) CALL Update_SUN()
+   IF ( Do_Update_RCONST ) CALL Update_RCONST()
    CALL Fun_SPLIT( Y, FIX, RCONST, P, D )
    Ydot = P - D*y
    TIME = Told
@@ -1309,8 +1347,8 @@ SUBROUTINE JacTemplate( T, Y, Jcb )
 
     Told = TIME
     TIME = T
-    CALL Update_SUN()
-    CALL Update_RCONST()
+    IF ( Do_Update_SUN    ) CALL Update_SUN()
+    IF ( Do_Update_RCONST ) CALL Update_RCONST()
 #ifdef FULL_ALGEBRA    
     CALL Jac_SP(Y, FIX, RCONST, JV)
     DO j=1,NVAR

--- a/int/rosenbrock_split.f90
+++ b/int/rosenbrock_split.f90
@@ -87,8 +87,8 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
    !            =  4 ! Call Update_SUN from within the integrator
    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-   !            =  6 ! Not implemented
-   !            =  7 ! Not implemented
+   !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+   !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
    CALL Integrator_Update_Options( ICNTRL(15),          &
                                    Do_Update_RCONST,    &
                                    Do_Update_PHOTO,     &
@@ -194,8 +194,8 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
 !        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
 !        =  4 :  Call Update_SUN from within the integrator
 !        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Not implemented
-!        =  7 :  Not implemented
+!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :  Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
 !
 !    RCNTRL(1)  -> Hmin, lower bound for the integration step size
 !          It is strongly recommended to keep Hmin = ZERO

--- a/int/rosenbrock_tlm.f90
+++ b/int/rosenbrock_tlm.f90
@@ -104,8 +104,8 @@ SUBROUTINE INTEGRATE_TLM( NTLM, Y, Y_tlm, TIN, TOUT, ATOL_tlm, RTOL_tlm,&
    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
    !            =  4 ! Call Update_SUN from within the integrator
    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-   !            =  6 ! Not implemented
-   !            =  7 ! Not implemented
+   !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+   !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
    CALL Integrator_Update_Options( ICNTRL(15),          &
                                    Do_Update_RCONST,    &
                                    Do_Update_PHOTO,     &
@@ -233,8 +233,8 @@ SUBROUTINE RosenbrockTLM(N,Y,NTLM,Y_tlm,                      &
 !        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
 !        =  4 :  Call Update_SUN from within the integrator
 !        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Not implemented
-!        =  7 :  Not implemented
+!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :  Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
 
 !    RCNTRL(1)  -> Hmin, lower bound for the integration step size
 !          It is strongly recommended to keep Hmin = ZERO

--- a/int/rosenbrock_tlm.f90
+++ b/int/rosenbrock_tlm.f90
@@ -44,8 +44,8 @@ CONTAINS ! Functions in the module KPP_ROOT_Integrator
 SUBROUTINE INTEGRATE_TLM( NTLM, Y, Y_tlm, TIN, TOUT, ATOL_tlm, RTOL_tlm,&
        ICNTRL_U, RCNTRL_U, ISTATUS_U, RSTATUS_U )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   IMPLICIT NONE        
-    
+   IMPLICIT NONE
+
 !~~~> Y - Concentrations
    KPP_REAL :: Y(NVAR)
 !~~~> NTLM - No. of sensitivity coefficients
@@ -72,7 +72,7 @@ SUBROUTINE INTEGRATE_TLM( NTLM, Y, Y_tlm, TIN, TOUT, ATOL_tlm, RTOL_tlm,&
    RCNTRL(1:20)  = 0.0_dp
    ISTATUS(1:20) = 0
    RSTATUS(1:20) = 0.0_dp
-   
+
    ICNTRL(1) = 0       ! non-autonomous
    ICNTRL(2) = 1       ! vector tolerances
    ICNTRL(3) = 5       ! choice of the method
@@ -94,12 +94,12 @@ SUBROUTINE INTEGRATE_TLM( NTLM, Y, Y_tlm, TIN, TOUT, ATOL_tlm, RTOL_tlm,&
 !~~~> Debug option: show number of steps
 !   Ntotal = Ntotal + ISTATUS(Nstp)
 !   PRINT*,'NSTEPS=',ISTATUS(Nstp),' (',Ntotal,')','  O3=', VAR(ind_O3)
-    
+
    IF (IERR < 0) THEN
      print *,'Rosenbrock: Unsucessful step at T=', &
          TIN,' (IERR=',IERR,')'
    END IF
-   
+
    STEPMIN = RSTATUS(Nhexit)
    ! if optional parameters are given for output they return information
    IF (PRESENT(ISTATUS_U)) ISTATUS_U(:) = ISTATUS(:)
@@ -113,7 +113,7 @@ SUBROUTINE RosenbrockTLM(N,Y,NTLM,Y_tlm,                      &
            Tstart,Tend,AbsTol,RelTol,AbsTol_tlm,RelTol_tlm,   &
            RCNTRL,ICNTRL,RSTATUS,ISTATUS,IERR)
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!   
+!
 !    TLM = Tangent Linear Model of a Rosenbrock Method
 !
 !    Solves the system y'=F(t,y) using a Rosenbrock method defined by:
@@ -123,40 +123,40 @@ SUBROUTINE RosenbrockTLM(N,Y,NTLM,Y_tlm,                      &
 !     Y_i = Y0 + \sum_{j=1}^{i-1} A(i,j)*K_j
 !     G * K_i = Fun( T_i, Y_i ) + \sum_{j=1}^S C(i,j)/H * K_j +
 !         gamma(i)*dF/dT(t0, Y0)
-!     Y1 = Y0 + \sum_{j=1}^S M(j)*K_j 
+!     Y1 = Y0 + \sum_{j=1}^S M(j)*K_j
 !
 !    For details on Rosenbrock methods and their implementation consult:
 !      E. Hairer and G. Wanner
 !      "Solving ODEs II. Stiff and differential-algebraic problems".
-!      Springer series in computational mathematics, Springer-Verlag, 1996.  
-!    The codes contained in the book inspired this implementation.       
+!      Springer series in computational mathematics, Springer-Verlag, 1996.
+!    The codes contained in the book inspired this implementation.
 !
 !    (C)  Adrian Sandu, August 2004
-!    Virginia Polytechnic Institute and State University    
+!    Virginia Polytechnic Institute and State University
 !    Contact: sandu@cs.vt.edu
-!    Revised by Philipp Miehe and Adrian Sandu, May 2006                  
+!    Revised by Philipp Miehe and Adrian Sandu, May 2006
 !    This implementation is part of KPP - the Kinetic PreProcessor
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!    
-!~~~>   INPUT ARGUMENTS: 
-!    
+!
+!~~~>   INPUT ARGUMENTS:
+!
 !-     Y(N)    -> vector of initial conditions (at T=Tstart)
-!      NTLM       -> dimension of linearized system, 
+!      NTLM       -> dimension of linearized system,
 !                   i.e. the number of sensitivity coefficients
 !-     Y_tlm(N*NTLM) -> vector of initial sensitivity conditions (at T=Tstart)
 !-    [Tstart,Tend]    -> time range of integration
-!     (if Tstart>Tend the integration is performed backwards in time)  
+!     (if Tstart>Tend the integration is performed backwards in time)
 !-    RelTol, AbsTol -> user precribed accuracy
-!- SUBROUTINE Fun( T, Y, Ydot ) -> ODE function, 
-!                       returns Ydot = Y' = F(T,Y) 
+!- SUBROUTINE Fun( T, Y, Ydot ) -> ODE function,
+!                       returns Ydot = Y' = F(T,Y)
 !- SUBROUTINE Jac( T, Y, Jcb ) -> Jacobian of the ODE function,
-!                       returns Jcb = dF/dY 
+!                       returns Jcb = dF/dY
 !-    ICNTRL(1:20)    -> integer inputs parameters
 !-    RCNTRL(1:20)    -> real inputs parameters
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !
-!~~~>     OUTPUT ARGUMENTS:  
-!     
+!~~~>     OUTPUT ARGUMENTS:
+!
 !-    Y(N)         -> vector of final states (at T->Tend)
 !-    Y_tlm(N*NTLM)-> vector of final sensitivities (at T=Tend)
 !-    ISTATUS(1:20)   -> integer output parameters
@@ -173,7 +173,7 @@ SUBROUTINE RosenbrockTLM(N,Y,NTLM,Y_tlm,                      &
 !           = -7 : Step size too small
 !           = -8 : Matrix is repeatedly singular
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-! 
+!
 !~~~>     INPUT PARAMETERS:
 !
 !    Note: For input parameters equal to zero the default values of the
@@ -188,8 +188,8 @@ SUBROUTINE RosenbrockTLM(N,Y,NTLM,Y_tlm,                      &
 !    ICNTRL(3)  -> selection of a particular Rosenbrock method
 !        = 0 :  default method is Rodas3
 !        = 1 :  method is  Ros2
-!        = 2 :  method is  Ros3 
-!        = 3 :  method is  Ros4 
+!        = 2 :  method is  Ros3
+!        = 3 :  method is  Ros4
 !        = 4 :  method is  Rodas3
 !        = 5 :  method is  Rodas4
 !
@@ -197,22 +197,28 @@ SUBROUTINE RosenbrockTLM(N,Y,NTLM,Y_tlm,                      &
 !        For ICNTRL(4)=0) the default value of 100000 is used
 !
 !    ICNTRL(12) -> switch for TLM truncation error control
-!               ICNTRL(12) = 0: TLM error is not used
-!               ICNTRL(12) = 1: TLM error is computed and used
+!        ICNTRL(12) = 0: TLM error is not used
+!        ICNTRL(12) = 1: TLM error is computed and used
+!
+!    ICNTRL(15) -> Determine whether to update rates within the solver step
+!        ICNTRL(15)=0 : Do not update rates within the solver step
+!        ICNTRL(15)=1 : Call Update_RCONST within solver step
+!        ICNTRL(15)=2 : Call Update_RCONST & Update_PHOTO w/in solver step
+!        ICNTRL(15)=3 : Call Update_SUN & Update_RCONST w/in solver step
 !
 !    RCNTRL(1)  -> Hmin, lower bound for the integration step size
-!          It is strongly recommended to keep Hmin = ZERO 
+!          It is strongly recommended to keep Hmin = ZERO
 !    RCNTRL(2)  -> Hmax, upper bound for the integration step size
 !    RCNTRL(3)  -> Hstart, starting value for the integration step size
-!          
+!
 !    RCNTRL(4)  -> FacMin, lower bound on step decrease factor (default=0.2)
 !    RCNTRL(5)  -> FacMin,upper bound on step increase factor (default=6)
 !    RCNTRL(6)  -> FacRej, step decrease factor after multiple rejections
 !                       (default=0.1)
-!    RCNTRL(7)  -> FacSafe, by which the new step is slightly smaller 
+!    RCNTRL(7)  -> FacSafe, by which the new step is slightly smaller
 !         than the predicted value  (default=0.9)
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-! 
+!
 !~~~>     OUTPUT PARAMETERS:
 !
 !    Note: each call to Rosenbrock adds the corrent no. of fcn calls
@@ -229,15 +235,15 @@ SUBROUTINE RosenbrockTLM(N,Y,NTLM,Y_tlm,                      &
 !    ISTATUS(8) = No. of singular matrix decompositions
 !    ISTATUS(9) = No. of Hessian calls
 !
-!    RSTATUS(1)  -> Texit, the time corresponding to the 
+!    RSTATUS(1)  -> Texit, the time corresponding to the
 !                   computed Y upon return
 !    RSTATUS(2)  -> Hexit, last accepted step before exit
-!    For multiple restarts, use Hexit as Hstart in the following run 
+!    For multiple restarts, use Hexit as Hstart in the following run
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   IMPLICIT NONE
-   
-!~~~>  Arguments   
+
+!~~~>  Arguments
    INTEGER,       INTENT(IN)    :: N, NTLM
    KPP_REAL, INTENT(INOUT) :: Y(N)
    KPP_REAL, INTENT(INOUT) :: Y_tlm(N,NTLM)
@@ -256,11 +262,11 @@ SUBROUTINE RosenbrockTLM(N,Y,NTLM,Y_tlm,                      &
                     ros_Alpha(6), ros_Gamma(6), ros_ELO
    LOGICAL :: ros_NewF(6)
    CHARACTER(LEN=12) :: ros_Name
-!~~~>  Local variables     
+!~~~>  Local variables
    KPP_REAL :: Roundoff, FacMin, FacMax, FacRej, FacSafe
    KPP_REAL :: Hmin, Hmax, Hstart, Hexit
    KPP_REAL :: Texit
-   INTEGER :: i, UplimTol, Max_no_steps 
+   INTEGER :: i, UplimTol, Max_no_steps
    LOGICAL :: Autonomous, VectorTol, TLMtruncErr
 !~~~>   Parameters
    KPP_REAL, PARAMETER :: ZERO = 0.0d0, ONE  = 1.0d0
@@ -270,7 +276,7 @@ SUBROUTINE RosenbrockTLM(N,Y,NTLM,Y_tlm,                      &
    IERR          = 0
    ISTATUS(1:20) = 0
    RSTATUS(1:20) = ZERO
-   
+
 !~~~>  Autonomous or time dependent ODE. Default is time dependent.
    Autonomous = .NOT.(ICNTRL(1) == 0)
 
@@ -279,7 +285,7 @@ SUBROUTINE RosenbrockTLM(N,Y,NTLM,Y_tlm,                      &
    IF (ICNTRL(2) == 0) THEN
       VectorTol = .TRUE.
       UplimTol  = N
-   ELSE 
+   ELSE
       VectorTol = .FALSE.
       UplimTol  = 1
    END IF
@@ -297,99 +303,99 @@ SUBROUTINE RosenbrockTLM(N,Y,NTLM,Y_tlm,                      &
      CASE (5)
        CALL Rodas4
      CASE DEFAULT
-       PRINT * , 'Unknown Rosenbrock method: ICNTRL(3)=',ICNTRL(3) 
+       PRINT * , 'Unknown Rosenbrock method: ICNTRL(3)=',ICNTRL(3)
        CALL ros_ErrorMsg(-2,Tstart,ZERO,IERR)
        RETURN
    END SELECT
-   
+
 !~~~>   The maximum number of steps admitted
    IF (ICNTRL(4) == 0) THEN
       Max_no_steps = 200000
    ELSEIF (Max_no_steps > 0) THEN
       Max_no_steps=ICNTRL(4)
-   ELSE 
+   ELSE
       PRINT * ,'User-selected max no. of steps: ICNTRL(4)=',ICNTRL(4)
       CALL ros_ErrorMsg(-1,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
-!~~~> TLM truncation error control selection  
-      IF (ICNTRL(12) == 0) THEN 
+!~~~> TLM truncation error control selection
+      IF (ICNTRL(12) == 0) THEN
          TLMtruncErr = .FALSE.
       ELSE
          TLMtruncErr = .TRUE.
-      END IF      
-   
-!~~~>  Unit roundoff (1+Roundoff>1)  
+      END IF
+
+!~~~>  Unit roundoff (1+Roundoff>1)
    Roundoff = WLAMCH('E')
 
 !~~~>  Lower bound on the step size: (positive value)
    IF (RCNTRL(1) == ZERO) THEN
       Hmin = ZERO
-   ELSEIF (RCNTRL(1) > ZERO) THEN 
+   ELSEIF (RCNTRL(1) > ZERO) THEN
       Hmin = RCNTRL(1)
-   ELSE  
+   ELSE
       PRINT * , 'User-selected Hmin: RCNTRL(1)=', RCNTRL(1)
       CALL ros_ErrorMsg(-3,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
 !~~~>  Upper bound on the step size: (positive value)
    IF (RCNTRL(2) == ZERO) THEN
       Hmax = ABS(Tend-Tstart)
    ELSEIF (RCNTRL(2) > ZERO) THEN
       Hmax = MIN(ABS(RCNTRL(2)),ABS(Tend-Tstart))
-   ELSE  
+   ELSE
       PRINT * , 'User-selected Hmax: RCNTRL(2)=', RCNTRL(2)
       CALL ros_ErrorMsg(-3,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
 !~~~>  Starting step size: (positive value)
    IF (RCNTRL(3) == ZERO) THEN
       Hstart = MAX(Hmin,DeltaMin)
    ELSEIF (RCNTRL(3) > ZERO) THEN
       Hstart = MIN(ABS(RCNTRL(3)),ABS(Tend-Tstart))
-   ELSE  
+   ELSE
       PRINT * , 'User-selected Hstart: RCNTRL(3)=', RCNTRL(3)
       CALL ros_ErrorMsg(-3,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
-!~~~>  Step size can be changed s.t.  FacMin < Hnew/Hexit < FacMax 
+!~~~>  Step size can be changed s.t.  FacMin < Hnew/Hexit < FacMax
    IF (RCNTRL(4) == ZERO) THEN
       FacMin = 0.2d0
    ELSEIF (RCNTRL(4) > ZERO) THEN
       FacMin = RCNTRL(4)
-   ELSE  
+   ELSE
       PRINT * , 'User-selected FacMin: RCNTRL(4)=', RCNTRL(4)
       CALL ros_ErrorMsg(-4,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
    IF (RCNTRL(5) == ZERO) THEN
       FacMax = 6.0d0
    ELSEIF (RCNTRL(5) > ZERO) THEN
       FacMax = RCNTRL(5)
-   ELSE  
+   ELSE
       PRINT * , 'User-selected FacMax: RCNTRL(5)=', RCNTRL(5)
       CALL ros_ErrorMsg(-4,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
 !~~~>   FacRej: Factor to decrease step after 2 succesive rejections
    IF (RCNTRL(6) == ZERO) THEN
       FacRej = 0.1d0
    ELSEIF (RCNTRL(6) > ZERO) THEN
       FacRej = RCNTRL(6)
-   ELSE  
+   ELSE
       PRINT * , 'User-selected FacRej: RCNTRL(6)=', RCNTRL(6)
       CALL ros_ErrorMsg(-4,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
 !~~~>   FacSafe: Safety Factor in the computation of new step size
    IF (RCNTRL(7) == ZERO) THEN
       FacSafe = 0.9d0
    ELSEIF (RCNTRL(7) > ZERO) THEN
       FacSafe = RCNTRL(7)
-   ELSE  
+   ELSE
       PRINT * , 'User-selected FacSafe: RCNTRL(7)=', RCNTRL(7)
       CALL ros_ErrorMsg(-4,Tstart,ZERO,IERR)
-      RETURN      
+      RETURN
    END IF
 !~~~>  Check if tolerances are reasonable
     DO i=1,UplimTol
@@ -401,94 +407,95 @@ SUBROUTINE RosenbrockTLM(N,Y,NTLM,Y_tlm,                      &
         RETURN
       END IF
     END DO
-     
 
-!~~~>  CALL Rosenbrock method   
-   CALL ros_TLM_Int(Y, NTLM, Y_tlm,              &
-        Tstart, Tend, Texit,                     & 
+
+!~~~>  CALL Rosenbrock method
+   CALL ros_TLM_Int(ICNTRL, Y, NTLM, Y_tlm,      &
+        Tstart, Tend, Texit,                     &
 !  Error indicator
         IERR)
 
 
 CONTAINS ! Procedures internal to RosenbrockTLM
- 
- 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  SUBROUTINE ros_ErrorMsg(Code,T,H,IERR)
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !    Handles all error messages
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
-  
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
    KPP_REAL, INTENT(IN) :: T, H
    INTEGER, INTENT(IN)  :: Code
    INTEGER, INTENT(OUT) :: IERR
-   
+
    IERR = Code
    PRINT * , &
-     'Forced exit from Rosenbrock due to the following error:' 
-     
+     'Forced exit from Rosenbrock due to the following error:'
+
    SELECT CASE (Code)
-    CASE (-1)    
+    CASE (-1)
       PRINT * , '--> Improper value for maximal no of steps'
-    CASE (-2)    
+    CASE (-2)
       PRINT * , '--> Selected Rosenbrock method not implemented'
-    CASE (-3)    
+    CASE (-3)
       PRINT * , '--> Hmin/Hmax/Hstart must be positive'
-    CASE (-4)    
+    CASE (-4)
       PRINT * , '--> FacMin/FacMax/FacRej must be positive'
-    CASE (-5) 
+    CASE (-5)
       PRINT * , '--> Improper tolerance values'
-    CASE (-6) 
+    CASE (-6)
       PRINT * , '--> No of steps exceeds maximum bound'
-    CASE (-7) 
+    CASE (-7)
       PRINT * , '--> Step size too small: T + 10*H = T', &
             ' or H < Roundoff'
-    CASE (-8)    
+    CASE (-8)
       PRINT * , '--> Matrix is repeatedly singular'
     CASE DEFAULT
       PRINT *, 'Unknown Error code: ', Code
    END SELECT
-   
+
    PRINT *, "T=", T, "and H=", H
-     
+
  END SUBROUTINE ros_ErrorMsg
-   
-     
-   
+
+
+
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- SUBROUTINE ros_TLM_Int (Y, NTLM, Y_tlm,         &
+ SUBROUTINE ros_TLM_Int (ICNTRL, Y, NTLM, Y_tlm, &
         Tstart, Tend, T,                         &
 !~~~> Error indicator
         IERR )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!   Template for the implementation of a generic Rosenbrock method 
-!      defined by ros_S (no of stages)  
+!   Template for the implementation of a generic Rosenbrock method
+!      defined by ros_S (no of stages)
 !      and its coefficients ros_{A,C,M,E,Alpha,Gamma}
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   IMPLICIT NONE
-   
-!~~~> Input: the initial condition at Tstart; Output: the solution at T   
+!~~~> Input: KPP runtime options
+   INTEGER, INTENT(IN) :: ICNTRL(20)
+!~~~> Input: the initial condition at Tstart; Output: the solution at T
    KPP_REAL, INTENT(INOUT) :: Y(N)
 !~~~> Input: Number of sensitivity coefficients
-   INTEGER, INTENT(IN) :: NTLM 
-!~~~> Input: the initial sensitivites at Tstart; Output: the sensitivities at T   
+   INTEGER, INTENT(IN) :: NTLM
+!~~~> Input: the initial sensitivites at Tstart; Output: the sensitivities at T
    KPP_REAL, INTENT(INOUT) :: Y_tlm(N,NTLM)
-!~~~> Input: integration interval   
-   KPP_REAL, INTENT(IN) :: Tstart,Tend      
-!~~~> Output: time at which the solution is returned (T=Tend if success)   
-   KPP_REAL, INTENT(OUT) ::  T      
+!~~~> Input: integration interval
+   KPP_REAL, INTENT(IN) :: Tstart,Tend
+!~~~> Output: time at which the solution is returned (T=Tend if success)
+   KPP_REAL, INTENT(OUT) ::  T
 !~~~> Output: Error indicator
    INTEGER, INTENT(OUT) :: IERR
-! ~~~~ Local variables        
-   KPP_REAL :: Ynew(N), Fcn0(N), Fcn(N) 
+! ~~~~ Local variables
+   KPP_REAL :: Ynew(N), Fcn0(N), Fcn(N)
    KPP_REAL :: K(N*ros_S)
-   KPP_REAL :: Ynew_tlm(N,NTLM), Fcn0_tlm(N,NTLM), Fcn_tlm(N,NTLM) 
+   KPP_REAL :: Ynew_tlm(N,NTLM), Fcn0_tlm(N,NTLM), Fcn_tlm(N,NTLM)
    KPP_REAL :: K_tlm(N*ros_S,NTLM)
    KPP_REAL :: Hes0(NHESS), Tmp(N)
    KPP_REAL :: dFdT(N), dJdT(LU_NONZERO)
    KPP_REAL :: Jac0(LU_NONZERO), Jac(LU_NONZERO), Ghimj(LU_NONZERO)
-   KPP_REAL :: H, Hnew, HC, HG, Fac, Tau 
+   KPP_REAL :: H, Hnew, HC, HG, Fac, Tau
    KPP_REAL :: Err, Err0, Err1, Yerr(N), Yerr_tlm(N,NTLM)
    INTEGER  :: Pivot(N), Direction, ioffset, j, istage, itlm
    LOGICAL  :: RejectLastH, RejectMoreH, Singular
@@ -499,28 +506,28 @@ CONTAINS ! Procedures internal to RosenbrockTLM
 !   EXTERNAL WLAMCH
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   
+
 !~~~>  Initial preparations
    T = Tstart
    RSTATUS(Nhexit) = ZERO
    H = MIN( MAX(ABS(Hmin),ABS(Hstart)) , ABS(Hmax) )
    IF (ABS(H) <= 10.D0*Roundoff) H = DeltaMin
-   
+
    IF (Tend  >=  Tstart) THEN
      Direction = +1
    ELSE
      Direction = -1
-   END IF               
+   END IF
    H = Direction*H
 
    RejectLastH=.FALSE.
    RejectMoreH=.FALSE.
-   
-!~~~> Time loop begins below 
+
+!~~~> Time loop begins below
 
 TimeLoop: DO WHILE ( (Direction > 0).AND.((T-Tend)+Roundoff <= ZERO) &
-       .OR. (Direction < 0).AND.((Tend-T)+Roundoff <= ZERO) ) 
-      
+       .OR. (Direction < 0).AND.((Tend-T)+Roundoff <= ZERO) )
+
    IF ( ISTATUS(Nstp) > Max_no_steps ) THEN  ! Too many steps
       CALL ros_ErrorMsg(-6,T,H,IERR)
       RETURN
@@ -529,37 +536,37 @@ TimeLoop: DO WHILE ( (Direction > 0).AND.((T-Tend)+Roundoff <= ZERO) &
       CALL ros_ErrorMsg(-7,T,H,IERR)
       RETURN
    END IF
-   
-!~~~>  Limit H if necessary to avoid going beyond Tend   
+
+!~~~>  Limit H if necessary to avoid going beyond Tend
    Hexit = H
    H = MIN(H,ABS(Tend-T))
 
 !~~~>   Compute the function at current time
-   CALL FunTemplate(T,Y,Fcn0)
+   CALL FunTemplate( ICNTRL, T, Y, Fcn0 )
    ISTATUS(Nfun) = ISTATUS(Nfun) + 1
 
 !~~~>   Compute the Jacobian at current time
-   CALL JacTemplate(T,Y,Jac0)    
+   CALL JacTemplate( ICNTRL, T, Y, Jac0 )
    ISTATUS(Njac) = ISTATUS(Njac) + 1
-  
+
 !~~~>   Compute the Hessian at current time
-   CALL HessTemplate(T,Y,Hes0)
+   CALL HessTemplate( ICNTRL, T, Y, Hes0 )
    ISTATUS(Nhes) = ISTATUS(Nhes) + 1
-   
+
 !~~~>   Compute the TLM function at current time
    DO itlm = 1, NTLM
       CALL Jac_SP_Vec ( Jac0, Y_tlm(1,itlm), Fcn0_tlm(1,itlm) )
-   END DO  
-   
+   END DO
+
 !~~~>  Compute the function and Jacobian derivatives with respect to T
    IF (.NOT.Autonomous) THEN
-      CALL ros_FunTimeDerivative ( T, Roundoff, Y, Fcn0, dFdT )
-      CALL ros_JacTimeDerivative ( T, Roundoff, Y, Jac0, dJdT )
+      CALL ros_FunTimeDerivative ( ICNTRL, T, Roundoff, Y, Fcn0, dFdT )
+      CALL ros_JacTimeDerivative ( ICNTRL, T, Roundoff, Y, Jac0, dJdT )
    END IF
- 
+
 !~~~>  Repeat step calculation until current step accepted
-UntilAccepted: DO  
-   
+UntilAccepted: DO
+
    CALL ros_PrepareMatrix(H,Direction,ros_Gamma(1),&
           Jac0,Ghimj,Pivot,Singular)
    IF (Singular) THEN ! More than 5 consecutive failed decompositions
@@ -569,14 +576,14 @@ UntilAccepted: DO
 
 !~~~>   Compute the stages
 Stage: DO istage = 1, ros_S
-      
+
       ! Current istage offset. Current istage vector is K(ioffset+1:ioffset+N)
        ioffset = N*(istage-1)
 
       ! Initialize stage solution
        CALL WCOPY(N,Y,1,Ynew,1)
        CALL WCOPY(N*NTLM,Y_tlm,1,Ynew_tlm,1)
-      
+
       ! For the 1st istage the function has been computed previously
        IF ( istage == 1 ) THEN
          CALL WCOPY(N,Fcn0,1,Fcn,1)
@@ -585,82 +592,82 @@ Stage: DO istage = 1, ros_S
        ELSEIF ( ros_NewF(istage) ) THEN
          DO j = 1, istage-1
            CALL WAXPY(N,ros_A((istage-1)*(istage-2)/2+j),    &
-                     K(N*(j-1)+1),1,Ynew,1) 
-           DO itlm=1,NTLM                    
+                     K(N*(j-1)+1),1,Ynew,1)
+           DO itlm=1,NTLM
               CALL WAXPY(N,ros_A((istage-1)*(istage-2)/2+j), &
-                     K_tlm(N*(j-1)+1,itlm),1,Ynew_tlm(1,itlm),1) 
-           END DO                    
+                     K_tlm(N*(j-1)+1,itlm),1,Ynew_tlm(1,itlm),1)
+           END DO
          END DO
          Tau = T + ros_Alpha(istage)*Direction*H
-         CALL FunTemplate(Tau,Ynew,Fcn)   
+         CALL FunTemplate( ICNTRL, Tau, Ynew, Fcn )
          ISTATUS(Nfun) = ISTATUS(Nfun) + 1
-         CALL JacTemplate(Tau,Ynew,Jac)    
+         CALL JacTemplate( ICNTRL, Tau, Ynew, Jac )
          ISTATUS(Njac) = ISTATUS(Njac) + 1
-         DO itlm=1,NTLM 
+         DO itlm=1,NTLM
            CALL Jac_SP_Vec ( Jac, Ynew_tlm(1,itlm), Fcn_tlm(1,itlm) )
-         END DO              
+         END DO
        END IF ! if istage == 1 elseif ros_NewF(istage)
        CALL WCOPY(N,Fcn,1,K(ioffset+1),1)
-       DO itlm=1,NTLM   
+       DO itlm=1,NTLM
           CALL WCOPY(N,Fcn_tlm(1,itlm),1,K_tlm(ioffset+1,itlm),1)
-       END DO                
+       END DO
        DO j = 1, istage-1
          HC = ros_C((istage-1)*(istage-2)/2+j)/(Direction*H)
          CALL WAXPY(N,HC,K(N*(j-1)+1),1,K(ioffset+1),1)
-         DO itlm=1,NTLM 
+         DO itlm=1,NTLM
            CALL WAXPY(N,HC,K_tlm(N*(j-1)+1,itlm),1,K_tlm(ioffset+1,itlm),1)
-         END DO              
+         END DO
        END DO
        IF ((.NOT. Autonomous).AND.(ros_Gamma(istage).NE.ZERO)) THEN
          HG = Direction*H*ros_Gamma(istage)
          CALL WAXPY(N,HG,dFdT,1,K(ioffset+1),1)
-         DO itlm=1,NTLM 
+         DO itlm=1,NTLM
            CALL Jac_SP_Vec ( dJdT, Ynew_tlm(1,itlm), Tmp )
            CALL WAXPY(N,HG,Tmp,1,K_tlm(ioffset+1,itlm),1)
-         END DO              
+         END DO
        END IF
        CALL ros_Solve(Ghimj, Pivot, K(ioffset+1))
-       DO itlm=1,NTLM   
+       DO itlm=1,NTLM
          CALL Hess_Vec ( Hes0, K(ioffset+1), Y_tlm(1,itlm), Tmp )
          CALL WAXPY(N,ONE,Tmp,1,K_tlm(ioffset+1,itlm),1)
          CALL ros_Solve(Ghimj, Pivot, K_tlm(ioffset+1,itlm))
-       END DO                
-      
-   END DO Stage     
-            
+       END DO
 
-!~~~>  Compute the new solution 
+   END DO Stage
+
+
+!~~~>  Compute the new solution
    CALL WCOPY(N,Y,1,Ynew,1)
    DO j=1,ros_S
       CALL WAXPY(N,ros_M(j),K(N*(j-1)+1),1,Ynew,1)
    END DO
-   DO itlm=1,NTLM       
+   DO itlm=1,NTLM
      CALL WCOPY(N,Y_tlm(1,itlm),1,Ynew_tlm(1,itlm),1)
      DO j=1,ros_S
        CALL WAXPY(N,ros_M(j),K_tlm(N*(j-1)+1,itlm),1,Ynew_tlm(1,itlm),1)
      END DO
    END DO
 
-!~~~>  Compute the error estimation 
+!~~~>  Compute the error estimation
    CALL Set2zero(N,Yerr)
-   DO j=1,ros_S     
+   DO j=1,ros_S
         CALL WAXPY(N,ros_E(j),K(N*(j-1)+1),1,Yerr,1)
-   END DO 
+   END DO
    Err = ros_ErrorNorm ( Y, Ynew, Yerr, AbsTol, RelTol, VectorTol )
    IF (TLMtruncErr) THEN
      Err1 = 0.0d0
      CALL Set2zero(N*NTLM,Yerr_tlm)
      DO itlm=1,NTLM
-       DO j=1,ros_S  
+       DO j=1,ros_S
          CALL WAXPY(N,ros_E(j),K_tlm(N*(j-1)+1,itlm),1,Yerr_tlm(1,itlm),1)
-       END DO 
+       END DO
      END DO
      Err = ros_ErrorNorm_tlm(Y_tlm,Ynew_tlm,Yerr_tlm,AbsTol_tlm,RelTol_tlm,Err,VectorTol)
    END IF
-  
+
 !~~~> New step size is bounded by FacMin <= Hnew/H <= FacMax
    Fac  = MIN(FacMax,MAX(FacMin,FacSafe/Err**(ONE/ros_ELO)))
-   Hnew = H*Fac  
+   Hnew = H*Fac
 
 !~~~>  Check the error magnitude and adjust step size
    ISTATUS(Nstp) = ISTATUS(Nstp) + 1
@@ -671,54 +678,54 @@ Stage: DO istage = 1, ros_S
       T = T + Direction*H
       Hnew = MAX(Hmin,MIN(Hnew,Hmax))
       IF (RejectLastH) THEN  ! No step size increase after a rejected step
-         Hnew = MIN(Hnew,H) 
-      END IF   
+         Hnew = MIN(Hnew,H)
+      END IF
       RSTATUS(Nhexit) = H
       RSTATUS(Nhnew)  = Hnew
       RSTATUS(Ntexit) = T
-      RejectLastH = .FALSE.  
+      RejectLastH = .FALSE.
       RejectMoreH = .FALSE.
       H = Hnew
       EXIT UntilAccepted ! EXIT THE LOOP: WHILE STEP NOT ACCEPTED
    ELSE           !~~~> Reject step
       IF (RejectMoreH) THEN
          Hnew = H*FacRej
-      END IF   
+      END IF
       RejectMoreH = RejectLastH
       RejectLastH = .TRUE.
       H = Hnew
       IF (ISTATUS(Nacc) >= 1) THEN
          ISTATUS(Nrej) = ISTATUS(Nrej) + 1
-      END IF    
+      END IF
    END IF ! Err <= 1
 
-   END DO UntilAccepted 
+   END DO UntilAccepted
 
-   END DO TimeLoop 
-   
+   END DO TimeLoop
+
 !~~~> Succesful exit
    IERR = 1  !~~~> The integration was successful
 
   END SUBROUTINE ros_TLM_Int
-   
-   
+
+
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  KPP_REAL FUNCTION ros_ErrorNorm ( Y, Ynew, Yerr, & 
+  KPP_REAL FUNCTION ros_ErrorNorm ( Y, Ynew, Yerr, &
                AbsTol, RelTol, VectorTol )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !~~~> Computes the "scaled norm" of the error vector Yerr
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   IMPLICIT NONE         
+   IMPLICIT NONE
 
-! Input arguments   
+! Input arguments
    KPP_REAL, INTENT(IN) :: Y(N), Ynew(N),    &
           Yerr(N), AbsTol(N), RelTol(N)
    LOGICAL, INTENT(IN) ::  VectorTol
-! Local variables     
-   KPP_REAL :: Err, Scale, Ymax   
+! Local variables
+   KPP_REAL :: Err, Scale, Ymax
    INTEGER  :: i
    KPP_REAL, PARAMETER :: ZERO = 0.0d0
-   
+
    Err = ZERO
    DO i=1,N
      Ymax = MAX(ABS(Y(i)),ABS(Ynew(i)))
@@ -732,25 +739,25 @@ Stage: DO istage = 1, ros_S
    Err  = SQRT(Err/N)
 
    ros_ErrorNorm = MAX(Err,1.0d-10)
-   
+
   END FUNCTION ros_ErrorNorm
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  KPP_REAL FUNCTION ros_ErrorNorm_tlm ( Y_tlm, Ynew_tlm, Yerr_tlm, & 
+  KPP_REAL FUNCTION ros_ErrorNorm_tlm ( Y_tlm, Ynew_tlm, Yerr_tlm, &
                AbsTol_tlm, RelTol_tlm, Fwd_Err, VectorTol )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !~~~> Computes the "scaled norm" of the error vector Yerr_tlm
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   IMPLICIT NONE         
+   IMPLICIT NONE
 
-! Input arguments   
+! Input arguments
    KPP_REAL, INTENT(IN) :: Y_tlm(N,NTLM), Ynew_tlm(N,NTLM),    &
           Yerr_tlm(N,NTLM), AbsTol_tlm(N,NTLM), RelTol_tlm(N,NTLM), Fwd_Err
    LOGICAL, INTENT(IN) ::  VectorTol
-! Local variables     
+! Local variables
    KPP_REAL :: TMP, Err
    INTEGER  :: itlm
-   
+
    Err = FWD_Err
    DO itlm = 1,NTLM
      TMP = ros_ErrorNorm(Y_tlm(1,itlm), Ynew_tlm(1,itlm),Yerr_tlm(1,itlm), &
@@ -759,28 +766,29 @@ Stage: DO istage = 1, ros_S
    END DO
 
    ros_ErrorNorm_tlm = MAX(Err,1.0d-10)
-   
+
   END FUNCTION ros_ErrorNorm_tlm
 
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  SUBROUTINE ros_FunTimeDerivative ( T, Roundoff, Y, &
+  SUBROUTINE ros_FunTimeDerivative ( ICNTRL, T, Roundoff, Y, &
                 Fcn0, dFdT )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !~~~> The time partial derivative of the function by finite differences
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   IMPLICIT NONE         
+   IMPLICIT NONE
 
-!~~~> Input arguments   
-   KPP_REAL, INTENT(IN) :: T, Roundoff, Y(N), Fcn0(N) 
-!~~~> Output arguments   
-   KPP_REAL, INTENT(OUT) :: dFdT(N)   
-!~~~> Local variables     
-   KPP_REAL :: Delta  
+!~~~> Input arguments
+   INTEGER,  INTENT(IN) :: ICNTRL(20)
+   KPP_REAL, INTENT(IN) :: T, Roundoff, Y(N), Fcn0(N)
+!~~~> Output arguments
+   KPP_REAL, INTENT(OUT) :: dFdT(N)
+!~~~> Local variables
+   KPP_REAL :: Delta
    KPP_REAL, PARAMETER :: DeltaMin = 1.0d-6
-   
+
    Delta = SQRT(Roundoff)*MAX(DeltaMin,ABS(T))
-   CALL FunTemplate(T+Delta,Y,dFdT)   
+   CALL FunTemplate( ICNTRL, T+Delta, Y, dFdT )
    ISTATUS(Nfun) = ISTATUS(Nfun) + 1
    CALL WAXPY(N,(-ONE),Fcn0,1,dFdT,1)
    CALL WSCAL(N,(ONE/Delta),dFdT,1)
@@ -789,23 +797,24 @@ Stage: DO istage = 1, ros_S
 
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  SUBROUTINE ros_JacTimeDerivative ( T, Roundoff, Y, &
+  SUBROUTINE ros_JacTimeDerivative ( ICNTRL, T, Roundoff, Y, &
                 Jac0, dJdT )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !~~~> The time partial derivative of the Jacobian by finite differences
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   IMPLICIT NONE         
+   IMPLICIT NONE
 
-!~~~> Input arguments   
-   KPP_REAL, INTENT(IN) :: T, Roundoff, Y(N), Jac0(LU_NONZERO) 
-!~~~> Output arguments   
-   KPP_REAL, INTENT(OUT) :: dJdT(LU_NONZERO)   
-!~~~> Local variables     
-   KPP_REAL Delta  
+!~~~> Input arguments
+   INTEGER,  INTENT(IN) :: ICNTRL(20)
+   KPP_REAL, INTENT(IN) :: T, Roundoff, Y(N), Jac0(LU_NONZERO)
+!~~~> Output arguments
+   KPP_REAL, INTENT(OUT) :: dJdT(LU_NONZERO)
+!~~~> Local variables
+   KPP_REAL Delta
    KPP_REAL, PARAMETER :: ONE = 1.0d0, DeltaMin = 1.0d-6
-   
+
    Delta = SQRT(Roundoff)*MAX(DeltaMin,ABS(T))
-   CALL JacTemplate(T+Delta,Y,dJdT)    
+   CALL JacTemplate( ICNTRL, T+Delta, Y, dJdT )
    ISTATUS(Njac) = ISTATUS(Njac) + 1
    CALL WAXPY(LU_NONZERO,(-ONE),Jac0,1,dJdT,1)
    CALL WSCAL(LU_NONZERO,(ONE/Delta),dJdT,1)
@@ -813,7 +822,7 @@ Stage: DO istage = 1, ros_S
   END SUBROUTINE ros_JacTimeDerivative
 
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE ros_PrepareMatrix ( H, Direction, gam, &
              Jac0, Ghimj, Pivot, Singular )
 ! --- --- --- --- --- --- --- --- --- --- --- --- ---
@@ -824,27 +833,27 @@ Stage: DO istage = 1, ros_S
 !       -half the step size if LU decomposition fails and retry
 !       -exit after 5 consecutive fails
 ! --- --- --- --- --- --- --- --- --- --- --- --- ---
-   IMPLICIT NONE         
-   
-!~~~> Input arguments   
+   IMPLICIT NONE
+
+!~~~> Input arguments
    KPP_REAL, INTENT(IN) ::  gam, Jac0(LU_NONZERO)
    INTEGER, INTENT(IN) ::  Direction
-!~~~> Output arguments   
+!~~~> Output arguments
    KPP_REAL, INTENT(OUT) :: Ghimj(LU_NONZERO)
    LOGICAL, INTENT(OUT) ::  Singular
    INTEGER, INTENT(OUT) ::  Pivot(N)
-!~~~> Inout arguments   
+!~~~> Inout arguments
    KPP_REAL, INTENT(INOUT) :: H   ! step size is decreased when LU fails
-!~~~> Local variables     
+!~~~> Local variables
    INTEGER  :: i, ISING, Nconsecutive
    KPP_REAL ::  ghinv
    KPP_REAL, PARAMETER :: ONE  = 1.0d0, HALF = 0.5d0
-   
+
    Nconsecutive = 0
    Singular = .TRUE.
-   
+
    DO WHILE (Singular)
-   
+
 !~~~>    Construct Ghimj = 1/(H*ham) - Jac0
      CALL WCOPY(LU_NONZERO,Jac0,1,Ghimj,1)
      CALL WSCAL(LU_NONZERO,(-ONE),Ghimj,1)
@@ -852,103 +861,103 @@ Stage: DO istage = 1, ros_S
      DO i=1,N
        Ghimj(LU_DIAG(i)) = Ghimj(LU_DIAG(i))+ghinv
      END DO
-!~~~>    Compute LU decomposition 
+!~~~>    Compute LU decomposition
      CALL ros_Decomp( Ghimj, Pivot, ISING )
      IF (ISING == 0) THEN
-!~~~>    If successful done 
-        Singular = .FALSE. 
+!~~~>    If successful done
+        Singular = .FALSE.
      ELSE ! ISING .ne. 0
 !~~~>    If unsuccessful half the step size; if 5 consecutive fails then return
         ISTATUS(Nsng) = ISTATUS(Nsng) + 1
         Nconsecutive = Nconsecutive+1
-        Singular = .TRUE. 
+        Singular = .TRUE.
         PRINT*,'Warning: LU Decomposition returned ISING = ',ISING
         IF (Nconsecutive <= 5) THEN ! Less than 5 consecutive failed decompositions
            H = H*HALF
         ELSE  ! More than 5 consecutive failed decompositions
            RETURN
         END IF  ! Nconsecutive
-      END IF    ! ISING 
-         
+      END IF    ! ISING
+
    END DO ! WHILE Singular
 
   END SUBROUTINE ros_PrepareMatrix
 
-  
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE ros_Decomp( A, Pivot, ISING )
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
-!  Template for the LU decomposition   
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!  Template for the LU decomposition
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    IMPLICIT NONE
-!~~~> Inout variables     
+!~~~> Inout variables
    KPP_REAL, INTENT(INOUT) :: A(LU_NONZERO)
-!~~~> Output variables     
+!~~~> Output variables
    INTEGER, INTENT(OUT) :: Pivot(N), ISING
-   
+
    CALL KppDecomp ( A, ISING )
 !~~~> Note: for a full matrix use Lapack:
-!     CALL  DGETRF( N, N, A, N, Pivot, ISING ) 
+!     CALL  DGETRF( N, N, A, N, Pivot, ISING )
    Pivot(1) = 1
-    
+
    ISTATUS(Ndec) = ISTATUS(Ndec) + 1
 
   END SUBROUTINE ros_Decomp
- 
- 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE ros_Solve( A, Pivot, b )
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
-!  Template for the forward/backward substitution (using pre-computed LU decomposition)   
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!  Template for the forward/backward substitution (using pre-computed LU decomposition)
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    IMPLICIT NONE
-!~~~> Input variables 
+!~~~> Input variables
 #ifdef FULL_ALGEBRA
    KPP_REAL, INTENT(IN) :: A(N,N)
    INTEGER :: ISING
-#else    
+#else
    KPP_REAL, INTENT(IN) :: A(LU_NONZERO)
-#endif   
+#endif
    INTEGER, INTENT(IN) :: Pivot(N)
-!~~~> InOut variables     
+!~~~> InOut variables
    KPP_REAL, INTENT(INOUT) :: b(N)
-   
+
 #ifdef FULL_ALGEBRA
    CALL  DGETRS( 'N', N , 1, A, N, Pivot, b, N, ISING )
-#else    
+#else
    CALL KppSolve( A, b )
-#endif   
-     
+#endif
+
    ISTATUS(Nsol) = ISTATUS(Nsol) + 1
 
   END SUBROUTINE ros_Solve
 
- 
- 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
-  SUBROUTINE Ros2 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  SUBROUTINE Ros2
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ! --- AN L-STABLE METHOD, 2 stages, order 2
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
    IMPLICIT NONE
    DOUBLE PRECISION g
-   
+
     g = 1.0d0 + 1.0d0/SQRT(2.0d0)
-   
+
     rosMethod = RS2
 !~~~> Name of the method
-    ros_Name = 'ROS-2'   
+    ros_Name = 'ROS-2'
 !~~~> Number of stages
     ros_S = 2
-   
+
 !~~~> The coefficient matrices A and C are strictly lower triangular.
 !   The lower triangular (subdiagonal) elements are stored in row-wise order:
 !   A(2,1) = ros_A(1), A(3,1)=ros_A(2), A(3,2)=ros_A(3), etc.
 !   The general mapping formula is:
-!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )    
-!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )  
-   
+!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )
+!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )
+
     ros_A(1) = (1.d0)/g
     ros_C(1) = (-2.d0)/g
 !~~~> Does the stage i require a new function evaluation (ros_NewF(i)=TRUE)
@@ -958,43 +967,43 @@ Stage: DO istage = 1, ros_S
 !~~~> M_i = Coefficients for new step solution
     ros_M(1)= (3.d0)/(2.d0*g)
     ros_M(2)= (1.d0)/(2.d0*g)
-! E_i = Coefficients for error estimator    
+! E_i = Coefficients for error estimator
     ros_E(1) = 1.d0/(2.d0*g)
     ros_E(2) = 1.d0/(2.d0*g)
 !~~~> ros_ELO = estimator of local order - the minimum between the
 !    main and the embedded scheme orders plus one
-    ros_ELO = 2.0d0    
+    ros_ELO = 2.0d0
 !~~~> Y_stage_i ~ Y( T + H*Alpha_i )
     ros_Alpha(1) = 0.0d0
-    ros_Alpha(2) = 1.0d0 
-!~~~> Gamma_i = \sum_j  gamma_{i,j}    
+    ros_Alpha(2) = 1.0d0
+!~~~> Gamma_i = \sum_j  gamma_{i,j}
     ros_Gamma(1) = g
     ros_Gamma(2) =-g
-   
+
  END SUBROUTINE Ros2
 
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE Ros3
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ! --- AN L-STABLE METHOD, 3 stages, order 3, 2 function evaluations
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
-  
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
    IMPLICIT NONE
-   
+
     rosMethod = RS3
 !~~~> Name of the method
-   ros_Name = 'ROS-3'   
+   ros_Name = 'ROS-3'
 !~~~> Number of stages
    ros_S = 3
-   
+
 !~~~> The coefficient matrices A and C are strictly lower triangular.
 !   The lower triangular (subdiagonal) elements are stored in row-wise order:
 !   A(2,1) = ros_A(1), A(3,1)=ros_A(2), A(3,2)=ros_A(3), etc.
 !   The general mapping formula is:
-!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )    
-!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )  
-     
+!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )
+!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )
+
    ros_A(1)= 1.d0
    ros_A(2)= 1.d0
    ros_A(3)= 0.d0
@@ -1011,54 +1020,54 @@ Stage: DO istage = 1, ros_S
    ros_M(1) =  0.1d+01
    ros_M(2) =  0.61697947043828245592553615689730d+01
    ros_M(3) = -0.42772256543218573326238373806514d+00
-! E_i = Coefficients for error estimator    
+! E_i = Coefficients for error estimator
    ros_E(1) =  0.5d+00
    ros_E(2) = -0.29079558716805469821718236208017d+01
    ros_E(3) =  0.22354069897811569627360909276199d+00
 !~~~> ros_ELO = estimator of local order - the minimum between the
 !    main and the embedded scheme orders plus 1
-   ros_ELO = 3.0d0    
+   ros_ELO = 3.0d0
 !~~~> Y_stage_i ~ Y( T + H*Alpha_i )
    ros_Alpha(1)= 0.0d+00
    ros_Alpha(2)= 0.43586652150845899941601945119356d+00
    ros_Alpha(3)= 0.43586652150845899941601945119356d+00
-!~~~> Gamma_i = \sum_j  gamma_{i,j}    
+!~~~> Gamma_i = \sum_j  gamma_{i,j}
    ros_Gamma(1)= 0.43586652150845899941601945119356d+00
    ros_Gamma(2)= 0.24291996454816804366592249683314d+00
    ros_Gamma(3)= 0.21851380027664058511513169485832d+01
 
   END SUBROUTINE Ros3
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE Ros4
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !     L-STABLE ROSENBROCK METHOD OF ORDER 4, WITH 4 STAGES
-!     L-STABLE EMBEDDED ROSENBROCK METHOD OF ORDER 3 
+!     L-STABLE EMBEDDED ROSENBROCK METHOD OF ORDER 3
 !
 !      E. HAIRER AND G. WANNER, SOLVING ORDINARY DIFFERENTIAL
 !      EQUATIONS II. STIFF AND DIFFERENTIAL-ALGEBRAIC PROBLEMS.
 !      SPRINGER SERIES IN COMPUTATIONAL MATHEMATICS,
-!      SPRINGER-VERLAG (1990)         
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!      SPRINGER-VERLAG (1990)
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
    IMPLICIT NONE
-   
+
     rosMethod = RS4
 !~~~> Name of the method
-   ros_Name = 'ROS-4'   
+   ros_Name = 'ROS-4'
 !~~~> Number of stages
    ros_S = 4
-   
+
 !~~~> The coefficient matrices A and C are strictly lower triangular.
 !   The lower triangular (subdiagonal) elements are stored in row-wise order:
 !   A(2,1) = ros_A(1), A(3,1)=ros_A(2), A(3,2)=ros_A(3), etc.
 !   The general mapping formula is:
-!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )    
-!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )  
-     
+!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )
+!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )
+
    ros_A(1) = 0.2000000000000000d+01
    ros_A(2) = 0.1867943637803922d+01
    ros_A(3) = 0.2344449711399156d+00
@@ -1083,48 +1092,48 @@ Stage: DO istage = 1, ros_S
    ros_M(2) = 0.2870493262186792d+00
    ros_M(3) = 0.4353179431840180d+00
    ros_M(4) = 0.1093502252409163d+01
-!~~~> E_i  = Coefficients for error estimator    
+!~~~> E_i  = Coefficients for error estimator
    ros_E(1) =-0.2815431932141155d+00
    ros_E(2) =-0.7276199124938920d-01
    ros_E(3) =-0.1082196201495311d+00
    ros_E(4) =-0.1093502252409163d+01
 !~~~> ros_ELO  = estimator of local order - the minimum between the
 !    main and the embedded scheme orders plus 1
-   ros_ELO  = 4.0d0    
+   ros_ELO  = 4.0d0
 !~~~> Y_stage_i ~ Y( T + H*Alpha_i )
    ros_Alpha(1) = 0.D0
    ros_Alpha(2) = 0.1145640000000000d+01
    ros_Alpha(3) = 0.6552168638155900d+00
    ros_Alpha(4) = ros_Alpha(3)
-!~~~> Gamma_i = \sum_j  gamma_{i,j}    
+!~~~> Gamma_i = \sum_j  gamma_{i,j}
    ros_Gamma(1) = 0.5728200000000000d+00
    ros_Gamma(2) =-0.1769193891319233d+01
    ros_Gamma(3) = 0.7592633437920482d+00
    ros_Gamma(4) =-0.1049021087100450d+00
 
   END SUBROUTINE Ros4
-   
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE Rodas3
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ! --- A STIFFLY-STABLE METHOD, 4 stages, order 3
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
    IMPLICIT NONE
-   
+
     rosMethod = RD3
 !~~~> Name of the method
-   ros_Name = 'RODAS-3'   
+   ros_Name = 'RODAS-3'
 !~~~> Number of stages
    ros_S = 4
-   
+
 !~~~> The coefficient matrices A and C are strictly lower triangular.
 !   The lower triangular (subdiagonal) elements are stored in row-wise order:
 !   A(2,1) = ros_A(1), A(3,1)=ros_A(2), A(3,2)=ros_A(3), etc.
 !   The general mapping formula is:
-!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )    
-!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )  
- 
+!       A(i,j) = ros_A( (i-1)*(i-2)/2 + j )
+!       C(i,j) = ros_C( (i-1)*(i-2)/2 + j )
+
    ros_A(1) = 0.0d+00
    ros_A(2) = 2.0d+00
    ros_A(3) = 0.0d+00
@@ -1136,9 +1145,9 @@ Stage: DO istage = 1, ros_S
    ros_C(2) = 1.0d+00
    ros_C(3) =-1.0d+00
    ros_C(4) = 1.0d+00
-   ros_C(5) =-1.0d+00 
-   ros_C(6) =-(8.0d+00/3.0d+00) 
-         
+   ros_C(5) =-1.0d+00
+   ros_C(6) =-(8.0d+00/3.0d+00)
+
 !~~~> Does the stage i require a new function evaluation (ros_NewF(i)=TRUE)
 !   or does it re-use the function evaluation from stage i-1 (ros_NewF(i)=FALSE)
    ros_NewF(1)  = .TRUE.
@@ -1150,55 +1159,55 @@ Stage: DO istage = 1, ros_S
    ros_M(2) = 0.0d+00
    ros_M(3) = 1.0d+00
    ros_M(4) = 1.0d+00
-!~~~> E_i  = Coefficients for error estimator    
+!~~~> E_i  = Coefficients for error estimator
    ros_E(1) = 0.0d+00
    ros_E(2) = 0.0d+00
    ros_E(3) = 0.0d+00
    ros_E(4) = 1.0d+00
 !~~~> ros_ELO  = estimator of local order - the minimum between the
 !    main and the embedded scheme orders plus 1
-   ros_ELO  = 3.0d+00    
+   ros_ELO  = 3.0d+00
 !~~~> Y_stage_i ~ Y( T + H*Alpha_i )
    ros_Alpha(1) = 0.0d+00
    ros_Alpha(2) = 0.0d+00
    ros_Alpha(3) = 1.0d+00
    ros_Alpha(4) = 1.0d+00
-!~~~> Gamma_i = \sum_j  gamma_{i,j}    
+!~~~> Gamma_i = \sum_j  gamma_{i,j}
    ros_Gamma(1) = 0.5d+00
    ros_Gamma(2) = 1.5d+00
    ros_Gamma(3) = 0.0d+00
    ros_Gamma(4) = 0.0d+00
 
   END SUBROUTINE Rodas3
-    
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   SUBROUTINE Rodas4
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !     STIFFLY-STABLE ROSENBROCK METHOD OF ORDER 4, WITH 6 STAGES
 !
 !      E. HAIRER AND G. WANNER, SOLVING ORDINARY DIFFERENTIAL
 !      EQUATIONS II. STIFF AND DIFFERENTIAL-ALGEBRAIC PROBLEMS.
 !      SPRINGER SERIES IN COMPUTATIONAL MATHEMATICS,
-!      SPRINGER-VERLAG (1996)         
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!      SPRINGER-VERLAG (1996)
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
    IMPLICIT NONE
 
     rosMethod = RD4
 !~~~> Name of the method
-    ros_Name = 'RODAS-4'   
+    ros_Name = 'RODAS-4'
 !~~~> Number of stages
     ros_S = 6
 
 !~~~> Y_stage_i ~ Y( T + H*Alpha_i )
     ros_Alpha(1) = 0.000d0
     ros_Alpha(2) = 0.386d0
-    ros_Alpha(3) = 0.210d0 
+    ros_Alpha(3) = 0.210d0
     ros_Alpha(4) = 0.630d0
     ros_Alpha(5) = 1.000d0
     ros_Alpha(6) = 1.000d0
-        
-!~~~> Gamma_i = \sum_j  gamma_{i,j}    
+
+!~~~> Gamma_i = \sum_j  gamma_{i,j}
     ros_Gamma(1) = 0.2500000000000000d+00
     ros_Gamma(2) =-0.1043000000000000d+00
     ros_Gamma(3) = 0.1035000000000000d+00
@@ -1209,9 +1218,9 @@ Stage: DO istage = 1, ros_S
 !~~~> The coefficient matrices A and C are strictly lower triangular.
 !   The lower triangular (subdiagonal) elements are stored in row-wise order:
 !   A(2,1) = ros_A(1), A(3,1)=ros_A(2), A(3,2)=ros_A(3), etc.
-!   The general mapping formula is:  A(i,j) = ros_A( (i-1)*(i-2)/2 + j )    
-!                  C(i,j) = ros_C( (i-1)*(i-2)/2 + j )  
-     
+!   The general mapping formula is:  A(i,j) = ros_A( (i-1)*(i-2)/2 + j )
+!                  C(i,j) = ros_C( (i-1)*(i-2)/2 + j )
+
     ros_A(1) = 0.1544000000000000d+01
     ros_A(2) = 0.9466785280815826d+00
     ros_A(3) = 0.2557011698983284d+00
@@ -1252,7 +1261,7 @@ Stage: DO istage = 1, ros_S
     ros_M(5) = 1.0d+00
     ros_M(6) = 1.0d+00
 
-!~~~> E_i  = Coefficients for error estimator    
+!~~~> E_i  = Coefficients for error estimator
     ros_E(1) = 0.0d+00
     ros_E(2) = 0.0d+00
     ros_E(3) = 0.0d+00
@@ -1268,96 +1277,95 @@ Stage: DO istage = 1, ros_S
     ros_NewF(4) = .TRUE.
     ros_NewF(5) = .TRUE.
     ros_NewF(6) = .TRUE.
-     
+
 !~~~> ros_ELO  = estimator of local order - the minimum between the
 !        main and the embedded scheme orders plus 1
     ros_ELO = 4.0d0
-     
+
   END SUBROUTINE Rodas4
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 END SUBROUTINE RosenbrockTLM
 !  and all its internal procedures
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
-  
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
-SUBROUTINE FunTemplate( T, Y, Ydot )
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+SUBROUTINE FunTemplate( ICNTRL, T, Y, Ydot )
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !  Template for the ODE function call.
-!  Updates the rate coefficients (and possibly the fixed species) at each call    
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!  Updates the rate coefficients (and possibly the fixed species) at each call
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
    IMPLICIT NONE
-!~~~> Input variables     
+!~~~> Input variables
+   INTEGER  :: ICNTRL(20)
    KPP_REAL :: T, Y(NVAR)
-!~~~> Output variables     
+!~~~> Output variables
    KPP_REAL :: Ydot(NVAR)
 !~~~> Local variables
-   KPP_REAL :: Told     
+   KPP_REAL :: Told
 
    Told = TIME
    TIME = T
-   CALL Update_SUN()
-   CALL Update_RCONST()
+   IF ( ICNTRL(15) == 3 ) CALL Update_SUN()
+   IF ( ICNTRL(15) >= 1 ) CALL Update_RCONST()
    CALL Fun( Y, FIX, RCONST, Ydot )
    TIME = Told
-        
+
 END SUBROUTINE FunTemplate
 
- 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
-SUBROUTINE JacTemplate( T, Y, Jcb )
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+SUBROUTINE JacTemplate( ICNTRL, T, Y, Jcb )
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !  Template for the ODE Jacobian call.
-!  Updates the rate coefficients (and possibly the fixed species) at each call    
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!  Updates the rate coefficients (and possibly the fixed species) at each call
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     IMPLICIT NONE
-   
-!~~~> Input variables     
+
+!~~~> Input variables
+    INTEGER  :: ICNTRL(20)
     KPP_REAL :: T, Y(NVAR)
-!~~~> Output variables     
+!~~~> Output variables
     KPP_REAL :: Jcb(LU_NONZERO)
 !~~~> Local variables
-    KPP_REAL :: Told     
+    KPP_REAL :: Told
 
     Told = TIME
-    TIME = T   
-    CALL Update_SUN()
-    CALL Update_RCONST()
+    TIME = T
+    IF ( ICNTRL(15) == 3 ) CALL Update_SUN()
+    IF ( ICNTRL(15) >= 1 ) CALL Update_RCONST()
     CALL Jac_SP( Y, FIX, RCONST, Jcb )
     TIME = Told
-     
-END SUBROUTINE JacTemplate                                      
+
+END SUBROUTINE JacTemplate
 
 
- 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
-SUBROUTINE HessTemplate( T, Y, Hes )
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+SUBROUTINE HessTemplate( ICNTRL, T, Y, Hes )
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !  Template for the ODE Hessian call.
-!  Updates the rate coefficients (and possibly the fixed species) at each call    
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+!  Updates the rate coefficients (and possibly the fixed species) at each call
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     IMPLICIT NONE
-    
-!~~~> Input variables     
+
+!~~~> Input variables
+    INTEGER :: ICNTRL(20)
     KPP_REAL :: T, Y(NVAR)
-!~~~> Output variables     
+!~~~> Output variables
     KPP_REAL :: Hes(NHESS)
 !~~~> Local variables
-    KPP_REAL :: Told     
+    KPP_REAL :: Told
 
     Told = TIME
-    TIME = T   
-    CALL Update_SUN()
-    CALL Update_RCONST()
+    TIME = T
+    IF ( ICNTRL(15) == 3 ) CALL Update_SUN()
+    IF ( ICNTRL(15) >= 1 ) CALL Update_RCONST()
     CALL Hessian( Y, FIX, RCONST, Hes )
     TIME = Told
 
-END SUBROUTINE HessTemplate                                      
+END SUBROUTINE HessTemplate
 
 END MODULE KPP_ROOT_Integrator
-
-
-
-

--- a/int/runge_kutta.f90
+++ b/int/runge_kutta.f90
@@ -93,8 +93,8 @@ CONTAINS
     !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
     !            =  4 ! Call Update_SUN from within the integrator
     !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-    !            =  6 ! Not implemented
-    !            =  7 ! Not implemented
+    !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+    !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
     CALL Integrator_Update_Options( ICNTRL(15),          &
                                     Do_Update_RCONST,    &
                                     Do_Update_PHOTO,     &
@@ -216,8 +216,8 @@ CONTAINS
 !        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
 !        =  4 :  Call Update_SUN from within the integrator
 !        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Not implemented
-!        =  7 :  Not implemented
+!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :  Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
 !
 !~~~>  Real input parameters:
 !

--- a/int/runge_kutta.f90
+++ b/int/runge_kutta.f90
@@ -26,6 +26,13 @@ MODULE KPP_ROOT_Integrator
   PUBLIC
   SAVE
 
+!~~~> Flags to determine if we should call the UPDATE_* routines from within 
+!~~~> the integrator.  If using KPP in an external model, you might want to
+!~~~> disable these calls (via ICNTRL(15)) to avoid excess computations.
+  LOGICAL :: Do_Update_RCONST
+  LOGICAL :: Do_Update_PHOTO
+  LOGICAL :: Do_Update_SUN
+
 !~~~>  Statistics on the work performed by the Runge-Kutta method
   INTEGER, PARAMETER :: Nfun=1, Njac=2, Nstp=3, Nacc=4, &
     Nrej=5, Ndec=6, Nsol=7, Nsng=8, Ntexit=1, Nhacc=2, Nhnew=3
@@ -37,8 +44,9 @@ CONTAINS
   SUBROUTINE INTEGRATE( TIN, TOUT, &
     ICNTRL_U, RCNTRL_U, ISTATUS_U, RSTATUS_U, IERR_U )
 
-    USE KPP_ROOT_Parameters, ONLY: NVAR
-    USE KPP_ROOT_Global,     ONLY: ATOL,RTOL,VAR
+    USE KPP_ROOT_Parameters, ONLY : NVAR
+    USE KPP_ROOT_Global,     ONLY : ATOL,RTOL,VAR
+    USE KPP_ROOT_Util,       ONLY : Integrator_Update_Options
 
     IMPLICIT NONE
 
@@ -75,7 +83,24 @@ CONTAINS
       WHERE(RCNTRL_U(:) > 0) RCNTRL(:) = RCNTRL_U(:)
     END IF
 
+    ! Determine the settings of the Do_Update_* flags, which determine
+    ! whether or not we need to call Update_* routines in the integrator
+    ! (or not, if we are calling them from a higher-level)
+    ! ICNTRL(15) = -1 ! Do not call Update_* functions within the integrator
+    !            =  0 ! Status quo
+    !            =  1 ! Call Update_RCONST from within the integrator
+    !            =  2 ! Call Update_PHOTO from within the integrator
+    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
+    !            =  4 ! Call Update_SUN from within the integrator
+    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
+    !            =  6 ! Not implemented
+    !            =  7 ! Not implemented
+    CALL Integrator_Update_Options( ICNTRL(15),          &
+                                    Do_Update_RCONST,    &
+                                    Do_Update_PHOTO,     &
+                                    Do_Update_Sun       )
     
+    ! Call the integrator
     T1 = TIN; T2 = TOUT
     CALL RungeKutta(  NVAR, T1, T2, VAR, RTOL, ATOL, &
                       RCNTRL,ICNTRL,RSTATUS,ISTATUS,IERR  )
@@ -182,6 +207,17 @@ CONTAINS
 !              the choice 1 seems to produce safer results;
 !              for simple problems, the choice 2 produces
 !              often slightly faster runs
+!
+!    ICNTRL(15) -> Toggles calling of Update_* functions w/in the integrator
+!        = -1 :  Do not call Update_* functions within the integrator
+!        =  0 :  Status quo
+!        =  1 :  Call Update_RCONST from within the integrator
+!        =  2 :  Call Update_PHOTO from within the integrator
+!        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
+!        =  4 :  Call Update_SUN from within the integrator
+!        =  5 :  Call Update_SUN and Update_RCONST from within the int.
+!        =  6 :  Not implemented
+!        =  7 :  Not implemented
 !
 !~~~>  Real input parameters:
 !
@@ -1830,9 +1866,9 @@ firej:IF (FirstStep.OR.Reject) THEN
 
     Told = TIME
     TIME = T
-    CALL Update_SUN()
-    CALL Update_RCONST()
-    CALL Update_PHOTO()
+    IF ( Do_Update_SUN    ) CALL Update_SUN()
+    IF ( Do_Update_RCONST ) CALL Update_RCONST()
+    IF ( Do_Update_PHOTO  ) CALL Update_PHOTO()
     TIME = Told
     
     CALL Fun(V, FIX, RCONST, FCT)
@@ -1862,9 +1898,9 @@ firej:IF (FirstStep.OR.Reject) THEN
 
     Told = TIME
     TIME = T
-    CALL Update_SUN()
-    CALL Update_RCONST()
-    CALL Update_PHOTO()
+    IF ( Do_Update_SUN    ) CALL Update_SUN()
+    IF ( Do_Update_RCONST ) CALL Update_RCONST()
+    IF ( Do_Update_PHOTO  ) CALL Update_PHOTO()
     TIME = Told
     
 #ifdef FULL_ALGEBRA    

--- a/int/runge_kutta_adj.f90
+++ b/int/runge_kutta_adj.f90
@@ -115,8 +115,8 @@ CONTAINS
     !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
     !            =  4 ! Call Update_SUN from within the integrator
     !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-    !            =  6 ! Not implemented
-    !            =  7 ! Not implemented
+    !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+    !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
     CALL Integrator_Update_Options( ICNTRL(15),          &
                                     Do_Update_RCONST,    &
                                     Do_Update_PHOTO,     &
@@ -259,8 +259,8 @@ CONTAINS
 !        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
 !        =  4 :  Call Update_SUN from within the integrator
 !        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Not implemented
-!        =  7 :  Not implemented
+!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :  Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
 !
 !~~~>  Real input parameters:
 !

--- a/int/runge_kutta_tlm.f90
+++ b/int/runge_kutta_tlm.f90
@@ -26,6 +26,13 @@ MODULE KPP_ROOT_Integrator
   PUBLIC
   SAVE
 
+!~~~> Flags to determine if we should call the UPDATE_* routines from within 
+!~~~> the integrator.  If using KPP in an external model, you might want to
+!~~~> disable these calls (via ICNTRL(15)) to avoid excess computations.
+  LOGICAL :: Do_Update_RCONST
+  LOGICAL :: Do_Update_PHOTO
+  LOGICAL :: Do_Update_SUN
+
 !~~~>  Statistics on the work performed by the Runge-Kutta method
   INTEGER, PARAMETER :: Nfun=1, Njac=2, Nstp=3, Nacc=4, &
     Nrej=5, Ndec=6, Nsol=7, Nsng=8, Ntexit=1, Nhacc=2, Nhnew=3
@@ -39,8 +46,9 @@ SUBROUTINE INTEGRATE_TLM( NTLM, Y, Y_tlm, TIN, TOUT, ATOL_tlm, RTOL_tlm, &
        ICNTRL_U, RCNTRL_U, ISTATUS_U, RSTATUS_U, IERR_U )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    USE KPP_ROOT_Parameters, ONLY: NVAR
-    USE KPP_ROOT_Global,     ONLY: ATOL,RTOL,VAR
+    USE KPP_ROOT_Parameters, ONLY : NVAR
+    USE KPP_ROOT_Global,     ONLY : ATOL,RTOL,VAR
+    USE KPP_ROOT_Util,       ONLY : Integrator_Update_Options
 
     IMPLICIT NONE
 
@@ -89,6 +97,24 @@ SUBROUTINE INTEGRATE_TLM( NTLM, Y, Y_tlm, TIN, TOUT, ATOL_tlm, RTOL_tlm, &
       WHERE(RCNTRL_U(:) > 0) RCNTRL(:) = RCNTRL_U(:)
     END IF
 
+    ! Determine the settings of the Do_Update_* flags, which determine
+    ! whether or not we need to call Update_* routines in the integrator
+    ! (or not, if we are calling them from a higher-level)
+    ! ICNTRL(15) = -1 ! Do not call Update_* functions within the integrator
+    !            =  0 ! Status quo
+    !            =  1 ! Call Update_RCONST from within the integrator
+    !            =  2 ! Call Update_PHOTO from within the integrator
+    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
+    !            =  4 ! Call Update_SUN from within the integrator
+    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
+    !            =  6 ! Not implemented
+    !            =  7 ! Not implemented
+    CALL Integrator_Update_Options( ICNTRL(15),          &
+                                    Do_Update_RCONST,    &
+                                    Do_Update_PHOTO,     &
+                                    Do_Update_Sun       )
+
+    ! Call the integrator
     T1 = TIN; T2 = TOUT
     CALL RungeKuttaTLM(  NVAR, NTLM, Y, Y_tlm, T1, T2, RTOL, ATOL, &
                            RTOL_tlm, ATOL_tlm,                     &
@@ -209,6 +235,16 @@ SUBROUTINE INTEGRATE_TLM( NTLM, Y, Y_tlm, TIN, TOUT, ATOL_tlm, RTOL_tlm, &
 !               ICNTRL(12) = 0: TLM error is not used
 !               ICNTRL(12) = 1: TLM error is computed and used
 !
+!    ICNTRL(15) -> Toggles calling of Update_* functions w/in the integrator
+!        = -1 :  Do not call Update_* functions within the integrator
+!        =  0 :  Status quo
+!        =  1 :  Call Update_RCONST from within the integrator
+!        =  2 :  Call Update_PHOTO from within the integrator
+!        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
+!        =  4 :  Call Update_SUN from within the integrator
+!        =  5 :  Call Update_SUN and Update_RCONST from within the int.
+!        =  6 :  Not implemented
+!        =  7 :  Not implemented
 !
 !~~~>  Real input parameters:
 !
@@ -2167,9 +2203,9 @@ firej:IF (FirstStep.OR.Reject) THEN
 
     Told = TIME
     TIME = T
-    CALL Update_SUN()
-    CALL Update_RCONST()
-    CALL Update_PHOTO()
+    IF ( Do_Update_SUN    ) CALL Update_SUN()
+    IF ( Do_Update_RCONST ) CALL Update_RCONST()
+    IF ( Do_Update_PHOTO  ) CALL Update_PHOTO()
     TIME = Told
     
     CALL Fun(V, FIX, RCONST, FCT)
@@ -2202,9 +2238,9 @@ firej:IF (FirstStep.OR.Reject) THEN
 
     Told = TIME
     TIME = T
-    CALL Update_SUN()
-    CALL Update_RCONST()
-    CALL Update_PHOTO()
+    IF ( Do_Update_SUN    ) CALL Update_SUN()
+    IF ( Do_Update_RCONST ) CALL Update_RCONST()
+    IF ( Do_Update_PHOTO  ) CALL Update_PHOTO()
     TIME = Told
     
 #ifdef FULL_ALGEBRA    

--- a/int/runge_kutta_tlm.f90
+++ b/int/runge_kutta_tlm.f90
@@ -107,8 +107,8 @@ SUBROUTINE INTEGRATE_TLM( NTLM, Y, Y_tlm, TIN, TOUT, ATOL_tlm, RTOL_tlm, &
     !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
     !            =  4 ! Call Update_SUN from within the integrator
     !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-    !            =  6 ! Not implemented
-    !            =  7 ! Not implemented
+    !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+    !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
     CALL Integrator_Update_Options( ICNTRL(15),          &
                                     Do_Update_RCONST,    &
                                     Do_Update_PHOTO,     &
@@ -243,8 +243,8 @@ SUBROUTINE INTEGRATE_TLM( NTLM, Y, Y_tlm, TIN, TOUT, ATOL_tlm, RTOL_tlm, &
 !        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
 !        =  4 :  Call Update_SUN from within the integrator
 !        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Not implemented
-!        =  7 :  Not implemented
+!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :  Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
 !
 !~~~>  Real input parameters:
 !

--- a/int/sdirk.f90
+++ b/int/sdirk.f90
@@ -89,8 +89,8 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
    !            =  4 ! Call Update_SUN from within the integrator
    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-   !            =  6 ! Not implemented
-   !            =  7 ! Not implemented
+   !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+   !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
    CALL Integrator_Update_Options( ICNTRL(15),          &
                                    Do_Update_RCONST,    &
                                    Do_Update_PHOTO,     &
@@ -202,8 +202,8 @@ SUBROUTINE INTEGRATE( TIN, TOUT, &
 !        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
 !        =  4 :  Call Update_SUN from within the integrator
 !        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Not implemented
-!        =  7 :  Not implemented
+!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :  Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
 !
 !~~~>  Real parameters
 !

--- a/int/sdirk_adj.f90
+++ b/int/sdirk_adj.f90
@@ -26,7 +26,14 @@ MODULE KPP_ROOT_Integrator
   IMPLICIT NONE
   PUBLIC
   SAVE
-  
+
+!~~~> Flags to determine if we should call the UPDATE_* routines from within 
+!~~~> the integrator.  If using KPP in an external model, you might want to
+!~~~> disable these calls (via ICNTRL(15)) to avoid excess computations.
+  LOGICAL :: Do_Update_RCONST
+  LOGICAL :: Do_Update_PHOTO
+  LOGICAL :: Do_Update_SUN
+
 !~~~>  Statistics on the work performed by the SDIRK method
   INTEGER, PARAMETER :: Nfun=1, Njac=2, Nstp=3, Nacc=4,  &
            Nrej=5, Ndec=6, Nsol=7, Nsng=8,               &
@@ -40,6 +47,8 @@ SUBROUTINE INTEGRATE_ADJ( NADJ, Y, Lambda, TIN, TOUT, &
 
    USE KPP_ROOT_Parameters
    USE KPP_ROOT_Global
+   USE KPP_ROOT_Util, ONLY : Integrator_Update_Options
+
    IMPLICIT NONE
 
 !~~~> Y - Concentrations
@@ -89,7 +98,24 @@ SUBROUTINE INTEGRATE_ADJ( NADJ, Y, Lambda, TIN, TOUT, &
      WHERE(RCNTRL_U(:) > 0) RCNTRL(:) = RCNTRL_U(:)
    END IF
    
-   
+   ! Determine the settings of the Do_Update_* flags, which determine
+   ! whether or not we need to call Update_* routines in the integrator
+   ! (or not, if we are calling them from a higher-level)
+   ! ICNTRL(15) = -1 ! Do not call Update_* functions within the integrator
+   !            =  0 ! Status quo
+   !            =  1 ! Call Update_RCONST from within the integrator
+   !            =  2 ! Call Update_PHOTO from within the integrator
+   !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
+   !            =  4 ! Call Update_SUN from within the integrator
+   !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
+   !            =  6 ! Not implemented
+   !            =  7 ! Not implemented
+   CALL Integrator_Update_Options( ICNTRL(15),          &
+                                   Do_Update_RCONST,    &
+                                   Do_Update_PHOTO,     &
+                                   Do_Update_Sun       )
+
+   ! Call the integrator
    T1 = TIN; T2 = TOUT
    CALL SDIRKADJ( NVAR, NADJ, T1, T2, Y, Lambda,            &
                   RTOL, ATOL, ATOL_adj, RTOL_adj,           &
@@ -199,6 +225,17 @@ SUBROUTINE INTEGRATE_ADJ( NADJ, Y, Lambda, TIN, TOUT, &
 !        ICNTRL(8)=0 : do *not* save LU factorization (the default)
 !        ICNTRL(8)=1 : save LU factorization
 !        Note: if ICNTRL(7)=1 the LU factorization is *not* saved
+!
+!    ICNTRL(15) -> Toggles calling of Update_* functions w/in the integrator
+!        = -1 :  Do not call Update_* functions within the integrator
+!        =  0 :  Status quo
+!        =  1 :  Call Update_RCONST from within the integrator
+!        =  2 :  Call Update_PHOTO from within the integrator
+!        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
+!        =  4 :  Call Update_SUN from within the integrator
+!        =  5 :  Call Update_SUN and Update_RCONST from within the int.
+!        =  6 :  Not implemented
+!        =  7 :  Not implemented
 !
 !~~~>  Real parameters
 !
@@ -1614,8 +1651,8 @@ Hloop: DO WHILE (ISING /= 0)
       
       Told = TIME
       TIME = T
-      CALL Update_SUN()
-      CALL Update_RCONST()
+      IF ( Do_Update_SUN    ) CALL Update_SUN()
+      IF ( Do_Update_RCONST ) CALL Update_RCONST()
       
       CALL Fun( Y, FIX, RCONST, P )
       
@@ -1644,8 +1681,8 @@ Hloop: DO WHILE (ISING /= 0)
  
       Told = TIME
       TIME = T
-      CALL Update_SUN()
-      CALL Update_RCONST()
+      IF ( Do_Update_SUN    ) CALL Update_SUN()
+      IF ( Do_Update_RCONST ) CALL Update_RCONST()
 
 #ifdef FULL_ALGEBRA
       CALL Jac_SP(Y, FIX, RCONST, JS)

--- a/int/sdirk_adj.f90
+++ b/int/sdirk_adj.f90
@@ -108,8 +108,8 @@ SUBROUTINE INTEGRATE_ADJ( NADJ, Y, Lambda, TIN, TOUT, &
    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
    !            =  4 ! Call Update_SUN from within the integrator
    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-   !            =  6 ! Not implemented
-   !            =  7 ! Not implemented
+   !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+   !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
    CALL Integrator_Update_Options( ICNTRL(15),          &
                                    Do_Update_RCONST,    &
                                    Do_Update_PHOTO,     &
@@ -234,8 +234,8 @@ SUBROUTINE INTEGRATE_ADJ( NADJ, Y, Lambda, TIN, TOUT, &
 !        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
 !        =  4 :  Call Update_SUN from within the integrator
 !        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Not implemented
-!        =  7 :  Not implemented
+!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :  Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
 !
 !~~~>  Real parameters
 !

--- a/int/sdirk_tlm.f90
+++ b/int/sdirk_tlm.f90
@@ -105,8 +105,8 @@ SUBROUTINE INTEGRATE_TLM( NTLM, Y, Y_tlm, TIN, TOUT, ATOL_tlm,RTOL_tlm, &
     !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
     !            =  4 ! Call Update_SUN from within the integrator
     !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
-    !            =  6 ! Not implemented
-    !            =  7 ! Not implemented
+    !            =  6 ! Call Update_SUN and Update_PHOTO from within the int.
+    !            =  7 ! Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
     CALL Integrator_Update_Options( ICNTRL(15),          &
                                     Do_Update_RCONST,    &
                                     Do_Update_PHOTO,     &
@@ -233,8 +233,8 @@ SUBROUTINE INTEGRATE_TLM( NTLM, Y, Y_tlm, TIN, TOUT, ATOL_tlm,RTOL_tlm, &
 !        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
 !        =  4 :  Call Update_SUN from within the integrator
 !        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Not implemented
-!        =  7 :  Not implemented
+!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :  Call Update_SUN, Update_PHOTO and Update_RCONST from within the int.
 !
 !~~~>  Real parameters
 !

--- a/int/sdirk_tlm.f90
+++ b/int/sdirk_tlm.f90
@@ -26,7 +26,14 @@ MODULE KPP_ROOT_Integrator
   IMPLICIT NONE
   PUBLIC
   SAVE
-  
+
+!~~~> Flags to determine if we should call the UPDATE_* routines from within 
+!~~~> the integrator.  If using KPP in an external model, you might want to
+!~~~> disable these calls (via ICNTRL(15)) to avoid excess computations.
+  LOGICAL :: Do_Update_RCONST
+  LOGICAL :: Do_Update_PHOTO
+  LOGICAL :: Do_Update_SUN
+
 !~~~>  Statistics on the work performed by the SDIRK method
   INTEGER, PARAMETER :: Nfun=1, Njac=2, Nstp=3, Nacc=4,  &
            Nrej=5, Ndec=6, Nsol=7, Nsng=8,               &
@@ -39,8 +46,9 @@ SUBROUTINE INTEGRATE_TLM( NTLM, Y, Y_tlm, TIN, TOUT, ATOL_tlm,RTOL_tlm, &
        ICNTRL_U, RCNTRL_U, ISTATUS_U, RSTATUS_U, IERR_U )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    USE KPP_ROOT_Parameters, ONLY: NVAR,ind_O3
-    USE KPP_ROOT_Global,     ONLY: ATOL,RTOL,VAR
+    USE KPP_ROOT_Parameters, ONLY : NVAR,ind_O3
+    USE KPP_ROOT_Global,     ONLY : ATOL,RTOL,VAR
+    USE KPP_ROOT_Util,       ONLY : Integrator_Update_Options
 
     IMPLICIT NONE
 
@@ -87,7 +95,24 @@ SUBROUTINE INTEGRATE_TLM( NTLM, Y, Y_tlm, TIN, TOUT, ATOL_tlm,RTOL_tlm, &
       WHERE(RCNTRL_U(:) > 0) RCNTRL(:) = RCNTRL_U(:)
     END IF
 
+    ! Determine the settings of the Do_Update_* flags, which determine
+    ! whether or not we need to call Update_* routines in the integrator
+    ! (or not, if we are calling them from a higher-level)
+    ! ICNTRL(15) = -1 ! Do not call Update_* functions within the integrator
+    !            =  0 ! Status quo
+    !            =  1 ! Call Update_RCONST from within the integrator
+    !            =  2 ! Call Update_PHOTO from within the integrator
+    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
+    !            =  4 ! Call Update_SUN from within the integrator
+    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
+    !            =  6 ! Not implemented
+    !            =  7 ! Not implemented
+    CALL Integrator_Update_Options( ICNTRL(15),          &
+                                    Do_Update_RCONST,    &
+                                    Do_Update_PHOTO,     &
+                                    Do_Update_Sun       )
 
+    ! Call the integrator
     T1 = TIN; T2 = TOUT
     CALL SdirkTLM(  NVAR, NTLM, T1, T2, Y, Y_tlm, RTOL, ATOL, &
                     RTOL_tlm, ATOL_tlm, RCNTRL,ICNTRL,RSTATUS,ISTATUS,IERR  )
@@ -200,6 +225,16 @@ SUBROUTINE INTEGRATE_TLM( NTLM, Y, Y_tlm, TIN, TOUT, ATOL_tlm,RTOL_tlm, &
 !        ICNTRL(12) = 0: TLM error is not used
 !        ICNTRL(12) = 1: TLM error is computed and used
 !
+!    ICNTRL(15) -> Toggles calling of Update_* functions w/in the integrator
+!        = -1 :  Do not call Update_* functions within the integrator
+!        =  0 :  Status quo
+!        =  1 :  Call Update_RCONST from within the integrator
+!        =  2 :  Call Update_PHOTO from within the integrator
+!        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
+!        =  4 :  Call Update_SUN from within the integrator
+!        =  5 :  Call Update_SUN and Update_RCONST from within the int.
+!        =  6 :  Not implemented
+!        =  7 :  Not implemented
 !
 !~~~>  Real parameters
 !
@@ -1407,8 +1442,8 @@ Hloop: DO WHILE (ISING /= 0)
       
       Told = TIME
       TIME = T
-      CALL Update_SUN()
-      CALL Update_RCONST()
+      IF ( Do_Update_SUN    ) CALL Update_SUN()
+      IF ( Do_Update_RCONST ) CALL Update_RCONST()
       
       CALL Fun( Y, FIX, RCONST, P )
       
@@ -1438,8 +1473,8 @@ Hloop: DO WHILE (ISING /= 0)
  
       Told = TIME
       TIME = T
-      CALL Update_SUN()
-      CALL Update_RCONST()
+      IF ( Do_Update_SUN    ) CALL Update_SUN()
+      IF ( Do_Update_RCONST ) CALL Update_RCONST()
 
 #ifdef FULL_ALGEBRA
       CALL Jac_SP(Y, FIX, RCONST, JS)

--- a/int/tau_leap.f90
+++ b/int/tau_leap.f90
@@ -99,7 +99,6 @@ REAL, PRIVATE      :: zero = 0.0, half = 0.5, one = 1.0, two = 2.0,   &
 PRIVATE            :: integral
 INTEGER, PARAMETER :: dp = SELECTED_REAL_KIND(12, 60)
 
-
 CONTAINS
 
 
@@ -1623,6 +1622,8 @@ SUBROUTINE TauLeap(Nsteps, Tau, T, SCT, NmlcV, NmlcF)
 !      
 !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  USE KPP_ROOT_Util, ONLY : Integrator_Update_Options
+
   IMPLICIT NONE
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     
@@ -1633,7 +1634,7 @@ SUBROUTINE TauLeap(Nsteps, Tau, T, SCT, NmlcV, NmlcF)
       REAL   :: mu
       KPP_REAL :: A(NREACT), SCT(NREACT), x
       LOGICAL, SAVE :: First = .TRUE.
-   
+
       DO istep = 1, Nsteps
 
           ! Propensity vector

--- a/util/Makefile.f90
+++ b/util/Makefile.f90
@@ -118,7 +118,7 @@ clean:
 distclean:
 	rm -f KPP_ROOT*.o KPP_ROOT*.mod \
 	KPP_ROOT*.dat KPP_ROOT.exe KPP_ROOT.map \
-	KPP_ROOT*.f90 KPP_ROOT_*.mexglx
+	KPP_ROOT_*.f90 KPP_ROOT_*.mexglx
 
 KPP_ROOT_Precision.o: KPP_ROOT_Precision.f90
 	$(FC) $(FOPT) -c $<

--- a/util/util.f90
+++ b/util/util.f90
@@ -1,7 +1,7 @@
 ! ****************************************************************
-!                            
+!
 ! InitSaveData - Opens the data file for writing
-!   Parameters :                                                  
+!   Parameters :
 !
 ! ****************************************************************
 
@@ -16,10 +16,13 @@
 ! End of InitSaveData function
 ! ****************************************************************
 
-! ****************************************************************
-!                            
-! SaveData - Write LOOKAT species in the data file 
-!   Parameters :                                                  
+! ****************************************************! GenerateMatlab - Generates MATLAB file to load the data file
+!   Parameters :
+!                It will have a character string to prefix each
+!                species name with.     ************
+!
+! SaveData - Write LOOKAT species in the data file
+!   Parameters :
 !
 ! ****************************************************************
 
@@ -31,8 +34,8 @@
       INTEGER i
 
       WRITE(10,999) (TIME-TSTART)/3600.D0,  &
-                   (C(LOOKAT(i))/CFACTOR, i=1,NLOOKAT)
-999   FORMAT(E24.16,100(1X,E24.16))
+      (C(LOOKAT(i))/CFACTOR, i=1,NLOOKAT)
+ 999  FORMAT(E24.16,100(1X,E24.16))
 
       END SUBROUTINE SaveData
 
@@ -40,9 +43,9 @@
 ! ****************************************************************
 
 ! ****************************************************************
-!                            
-! CloseSaveData - Close the data file 
-!   Parameters :                                                  
+!
+! CloseSaveData - Close the data file
+!   Parameters :
 !
 ! ****************************************************************
 
@@ -58,11 +61,11 @@
 ! ****************************************************************
 
 ! ****************************************************************
-!                            
-! GenerateMatlab - Generates MATLAB file to load the data file 
-!   Parameters : 
-!                It will have a character string to prefix each 
-!                species name with.                                                 
+!
+! GenerateMatlab - Generates MATLAB file to load the data file
+!   Parameters :
+!                It will have a character string to prefix each
+!                species name with.
 !
 ! ****************************************************************
 
@@ -72,8 +75,8 @@
       USE KPP_ROOT_Global
       USE KPP_ROOT_Monitor
 
-      
-      CHARACTER(LEN=8) PREFIX 
+
+      CHARACTER(LEN=8) PREFIX
       INTEGER i
 
       open(20, file='KPP_ROOT.m')
@@ -90,7 +93,7 @@
         write(20,993) PREFIX, SPC_NAMES(LOOKAT(i)), PREFIX, i
 993     FORMAT(A1,A6,' = ',A1,'c(:,',I2,');')
       end do
-      
+
       CLOSE(20)
 
       END SUBROUTINE GenerateMatlab
@@ -99,3 +102,72 @@
 ! ****************************************************************
 
 
+! ****************************************************************
+!
+! Integrator_Update_Options - determine whether to call Update_RCONST,
+!    Update_PHOTO, and Update_SUN from within the integrator
+!
+!   Parameters:
+!    option (input)
+!        = -1 :  Do not call Update_* functions within the integrator
+!        =  0 :  Status quo: Call whichever functions are normally called
+!        =  1 :  Call Update_RCONST from within the integrator
+!        =  2 :  Call Update_PHOTO from within the integrator
+!        =  3 :  Call Update_RCONST and Update_PHOTO from within the int.
+!        =  4 :  Call Update_SUN from within the integrator
+!        =  5 :  Call Update_SUN and Update_RCONST from within the int.
+!        =  6 :  not implemented
+!        =  7 :  not implemented
+!
+!    Do_Update_RCONST (output):
+!        =T : Calls Update_RCONST from within the integrator
+!        =F : Does not call UPDATE_RCONST from w/in the int.
+!
+!    Do_Update_PHOTO (output):
+!        =T : Calls Update_PHOTO from within the integrator
+!        =F : Does not call UPDATE_PHOTO from w/in the int.
+!
+!    Do_Update_SUN (output):
+!        =T : Calls Update_SUN from within the integrator
+!        =F : Does not call UPDATE_SUN from w/in the int.
+!
+! ****************************************************************
+
+      SUBROUTINE Integrator_Update_Options( option,            &
+                                            Do_Update_RConst,  &
+                                            Do_Update_Photo,   &
+                                            Do_Update_Sun     )
+
+      !~~~> Input variables
+      INTEGER, INTENT(IN)  :: option
+
+      !~~~> Output variables
+      LOGICAL, INTENT(OUT) :: Do_Update_RCONST
+      LOGICAL, INTENT(OUT) :: Do_Update_PHOTO
+      LOGICAL, INTENT(OUT) :: Do_Update_SUN
+
+      ! Option -1: turn off all Update_* calls within the integrator
+      IF ( option == -1 ) THEN
+         Do_Update_RCONST = .FALSE.
+         Do_Update_PHOTO  = .FALSE.
+         Do_Update_SUN    = .FALSE.
+         RETURN
+      ENDIF
+
+      ! Option 0: status quo: Call update functions if defined
+      IF ( option == 0 ) THEN
+         Do_Update_RCONST = .TRUE.
+         Do_Update_PHOTO  = .TRUE.
+         Do_Update_SUN    = .TRUE.
+         RETURN
+      ENDIF
+
+      ! Otherwise determine from the value passed
+      Do_Update_RCONST = ( IAND( option, 1 ) > 0 )
+      Do_Update_PHOTO  = ( IAND( option, 2 ) > 0 )
+      Do_Update_SUN    = ( IAND( option, 4 ) > 0 )
+
+      END SUBROUTINE Integrator_Update_Options
+
+! End of Integrator_Update_Options function
+! ****************************************************************


### PR DESCRIPTION
## Overview
This PR implements the feature request in #9.  We now can use the setting of KPP runtime option `ICNTRL(15)` to determine whether or not rate constants can be updated within the integrator itself.

```F90
    ! Determine the settings of the Do_Update_* flags, which determine
    ! whether or not we need to call Update_* routines in the integrator
    ! (or not, if we are calling them from a higher-level)
    ! ICNTRL(15) = -1 ! Do not call Update_* functions within the integrator
    !            =  0 ! Status quo
    !            =  1 ! Call Update_RCONST from within the integrator
    !            =  2 ! Call Update_PHOTO from within the integrator
    !            =  3 ! Call Update_RCONST and Update_PHOTO from w/in the int.
    !            =  4 ! Call Update_SUN from within the integrator
    !            =  5 ! Call Update_SUN and Update_RCONST from within the int.   
    !            =  6 ! Not implemented```
```

NOTE: For global models such as GEOS-Chem, you will want to use `ICNTRL(15) =  -1`, as rates are computed outside of the integrator in order to avoid computational overhead.  But for other implementations using KPP (such as box models), it may be advantageous to be able to update rates at each call to the integrator.

## Validation

I ran the continuous integration tests manually at these 2 commits:

  1. Dev (with modifications) @ commit a9d2794e7a7611092edc0615a68dca8ebe4b6d29 :  [Dev CI test output log](https://github.com/KineticPreProcessor/KPP/files/8498013/log_new.txt)

  2. Ref (parent commit) @ commit 109ed9213860bc4357b45170e4eb92766681b407 :  [Ref CI test output log](https://github.com/KineticPreProcessor/KPP/files/8498008/log-dev.txt)

These files are identical, thus proving that the default settings (`ICNTRL(15) = 0`) yield the same results.