### PR TITLE
Add overloaded rate law functions for Fortran90 - to reduce unnecessary DBLE() calls

### DIFF
--- a/src/gen.c
+++ b/src/gen.c
@@ -3223,6 +3223,8 @@ case 'h':
     F90_Inline("  USE %s_Global", rootFileName );
     F90_Inline("  IMPLICIT NONE", rootFileName );
     F90_Inline("  INTEGER, PARAMETER :: ASSOC = 1, DISSOC = 2", rootFileName );
+    NewLines(1);
+    IncludeCode( "%s/util/UserRateLawsInterfaces", Home );
     F90_Inline("\nCONTAINS\n\n");
 
   if ( useStochastic ) {

--- a/util/UserRateLaws.f90
+++ b/util/UserRateLaws.f90
@@ -1,89 +1,171 @@
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !  User-defined Rate Law functions
-!  Note: the default argument type for rate laws, as read from the equations file, is single precision
-!        but all the internal calculations are performed in double precision
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!
+!  NOTE: For computational efficiency, we have created duplicate rate law
+!  routines here that take either all single precision or all double precision
+!  arguments.  Explicit casts to DBLE are skipped in the functions that take
+!  all double precision arguments (as this removes unneeded computations).
+!
+!  These functions are overloaded by INTERFACE statements, which are located
+!  in file UserRateLawsInterfaces.f90.  The UserRateLawsInterfaces.f90 file
+!  will be in-lined into the top of the KPP_ROOT_Rates module.
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-!~~~>  Arrhenius
-   KPP_REAL FUNCTION ARR( A0,B0,C0 )
-      REAL A0,B0,C0      
-      ARR =  DBLE(A0) * EXP(-DBLE(B0)/TEMP) * (TEMP/300.0_dp)**DBLE(C0)
-   END FUNCTION ARR        
+  FUNCTION ARR_dp( a0, b0, c0 ) RESULT( k )
+    ! Arrhenius function (dp args)
+    REAL(dp), INTENT(IN) :: a0, b0, c0
+    REAL(dp)             :: k
+    k =  a0 * EXP(-b0/TEMP) * (TEMP/300.0_dp)**C0
+  END FUNCTION ARR_dp
 
-!~~~> Simplified Arrhenius, with two arguments
-!~~~> Note: The argument B0 has a changed sign when compared to ARR
-   KPP_REAL FUNCTION ARR2( A0,B0 )
-      REAL A0,B0           
-      ARR2 =  DBLE(A0) * EXP( DBLE(B0)/TEMP )              
-   END FUNCTION ARR2          
-
-   KPP_REAL FUNCTION EP2(A0,C0,A2,C2,A3,C3)
-      REAL A0,C0,A2,C2,A3,C3
-      REAL(dp) K0,K2,K3            
-      K0 = DBLE(A0) * EXP(-DBLE(C0)/TEMP)
-      K2 = DBLE(A2) * EXP(-DBLE(C2)/TEMP)
-      K3 = DBLE(A3) * EXP(-DBLE(C3)/TEMP)
-      K3 = K3*CFACTOR*1.0E6_dp
-      EP2 = K0 + K3/(1.0_dp+K3/K2 )
-   END FUNCTION EP2
-
-   KPP_REAL FUNCTION EP3(A1,C1,A2,C2) 
-      REAL A1, C1, A2, C2
-      REAL(dp) K1, K2      
-      K1 = DBLE(A1) * EXP(-DBLE(C1)/TEMP)
-      K2 = DBLE(A2) * EXP(-DBLE(C2)/TEMP)
-      EP3 = K1 + K2*(1.0E6_dp*CFACTOR)
-   END FUNCTION EP3 
-
-   KPP_REAL FUNCTION FALL ( A0,B0,C0,A1,B1,C1,CF)
-      REAL A0,B0,C0,A1,B1,C1,CF
-      REAL(dp) K0, K1     
-      K0 = DBLE(A0) * EXP(-DBLE(B0)/TEMP)* (TEMP/300.0_dp)**DBLE(C0)
-      K1 = DBLE(A1) * EXP(-DBLE(B1)/TEMP)* (TEMP/300.0_dp)**DBLE(C1)
-      K0 = K0*CFACTOR*1.0E6_dp
-      K1 = K0/K1
-      FALL = (K0/(1.0_dp+K1))*   &
-           DBLE(CF)**(1.0_dp/(1.0_dp+(LOG10(K1))**2))
-   END FUNCTION FALL
+  FUNCTION ARR_sp( a0, b0, c0 ) RESULT( k )
+    ! Arrhenius function (sp args)
+    REAL(sp) :: a0, b0, c0
+    REAL(dp) :: k
+    k =  DBLE(a0) * EXP(-DBLE(b0)/TEMP) * (TEMP/300.0_dp)**DBLE(c0)
+  END FUNCTION ARR_sp
 
   !---------------------------------------------------------------------------
 
-  ELEMENTAL REAL(dp) FUNCTION k_3rd(temp,cair,k0_300K,n,kinf_300K,m,fc)
+  FUNCTION ARR2_dp( a0, b0 ) RESULT( k )
+    ! Simplified Arrhenius with two arguments (dp args)
+    ! Note: The argument B0 has a changed sign when compared to ARR
+    REAL(dp), INTENT(IN) :: a0, b0
+    REAL(dp)             :: k
+    k = a0 * EXP(b0/TEMP)
+  END FUNCTION ARR2_dp
+
+  FUNCTION ARR2_sp( a0, b0 ) RESULT( k )
+    ! Simplified Arrhenius with two arguments (sp args)
+    ! Note: The argument B0 has a changed sign when compared to ARR
+    REAL(sp), INTENT(IN) :: a0, b0
+    REAL(dp)             :: k
+    k = DBLE(a0) * EXP(DBLE(b0)/TEMP)
+  END FUNCTION ARR2_sp
+
+  !---------------------------------------------------------------------------
+
+  FUNCTION EP2_dp( a0, c0, a2, c2, a3, c3 ) RESULT( k )
+    ! EP2 function (dp args)
+    REAL(dp), INTENT(IN) :: a0, c0, a2, c2, a3, c3
+    REAL(dp)             :: k0, k2, k3, k
+    k0 = a0 * EXP(-c0/temp)
+    k2 = a2 * EXP(-c2/temp)
+    k3 = a3 * EXP(-c3/temp)
+    k3 = k3 * CFACTOR * 1.0E6_dp
+    k  = k0 + k3/(1.0_dp + k3/k2)
+  END FUNCTION EP2_dp
+
+  FUNCTION EP2_sp( a0, c0, a2, c2, a3, c3 ) RESULT( k )
+    ! EP2 function (sp args)
+    REAL(sp), INTENT(IN) :: a0, c0, a2, c2, a3, c3
+    REAL(dp)             :: k0, k2, k3, k
+    k0 = DBLE(a0) * EXP(-DBLE(c0)/TEMP)
+    k2 = DBLE(a2) * EXP(-DBLE(c2)/TEMP)
+    k3 = DBLE(a3) * EXP(-DBLE(c3)/TEMP)
+    k3 = k3 * CFACTOR * 1.0E6_dp
+    k  = k0 + K3/(1.0_dp + k3/k2)
+  END FUNCTION EP2_sp
+
+  !---------------------------------------------------------------------------
+
+  FUNCTION EP3_dp( a1, c1, a2, c2) RESULT( k )
+    REAL(dp), INTENT(IN) :: a1, c1, a2, c2
+    REAL(dp)             :: k1, k2, k
+    k1 = a1 * EXP(-c1/TEMP)
+    k2 = a2 * EXP(-c2/TEMP)
+    k  = k1 + k2*(1.0E6_dp * CFACTOR)
+  END FUNCTION EP3_dp
+
+  FUNCTION EP3_sp( a1, c1, a2, c2 ) RESULT( k )
+    REAL(sp), INTENT(IN) :: a1, c1, a2, c2
+    REAL(dp)             :: k1, k2, k
+    k1 = DBLE(a1) * EXP(-DBLE(c1)/TEMP)
+    k2 = DBLE(a2) * EXP(-DBLE(c2)/TEMP)
+    k  = k1 + k2*(1.0E6_dp * CFACTOR)
+  END FUNCTION EP3_sp
+
+  !---------------------------------------------------------------------------
+
+  FUNCTION FALL_dp( a0, b0, c0, a1, b1, c1, cf ) RESULT( k )
+    REAL(dp), INTENT(IN) :: a0, b0, c0, a1, b1, c1, cf
+    REAL(dp)             :: k0, k1, k
+    k0 = a0 * EXP(-b0/TEMP) * (TEMP/300.0_dp)**c0
+    k1 = a1 * EXP(-b1/TEMP) * (TEMP/300.0_dp)**c1
+    k0 = k0 * CFACTOR * 1.0E6_dp
+    k1 = k0 / k1
+    k  = (k0/(1.0_dp+k1)) * cf**(1.0_dp/(1.0_dp+(LOG10(k1))**2))
+  END FUNCTION FALL_dp
+
+  FUNCTION FALL_sp( a0, b0, c0, a1, b1, c1, cf ) RESULT( k )
+    REAL(sp), INTENT(IN) :: a0, b0, c0, a1, b1, c1, cf
+    REAL(dp)             :: k0, k1, k
+    k0 = DBLE(A0) * EXP(-DBLE(B0)/TEMP)* (TEMP/300.0_dp)**DBLE(C0)
+    k1 = DBLE(A1) * EXP(-DBLE(B1)/TEMP)* (TEMP/300.0_dp)**DBLE(C1)
+    k0 = k0 * CFACTOR * 1.0E6_dp
+    k1 = k0 / k1
+    k  = (k0/(1.0_dp+k1)) * DBLE(cf)**(1.0_dp/(1.0_dp+(LOG10(k1))**2))
+  END FUNCTION FALL_sp
+
+  !---------------------------------------------------------------------------
+
+  ELEMENTAL REAL(dp) FUNCTION k_3rd_dp(temp,cair,k0_300K,n,kinf_300K,m,fc)
 
     INTRINSIC LOG10
 
     REAL(dp), INTENT(IN) :: temp      ! temperature [K]
     REAL(dp), INTENT(IN) :: cair      ! air concentration [molecules/cm3]
-    REAL,     INTENT(IN) :: k0_300K   ! low pressure limit at 300 K
-    REAL,     INTENT(IN) :: n         ! exponent for low pressure limit
-    REAL,     INTENT(IN) :: kinf_300K ! high pressure limit at 300 K
-    REAL,     INTENT(IN) :: m         ! exponent for high pressure limit
-    REAL,     INTENT(IN) :: fc        ! broadening factor (usually fc=0.6)
+    REAL(dp), INTENT(IN) :: k0_300K   ! low pressure limit at 300 K
+    REAL(dp), INTENT(IN) :: n         ! exponent for low pressure limit
+    REAL(dp), INTENT(IN) :: kinf_300K ! high pressure limit at 300 K
+    REAL(dp), INTENT(IN) :: m         ! exponent for high pressure limit
+    REAL(dp), INTENT(IN) :: fc        ! broadening factor (usually fc=0.6)
     REAL(dp) :: zt_help, k0_T, kinf_T, k_ratio
 
-    zt_help = 300._dp/temp
-    k0_T    = k0_300K   * zt_help**(n) * cair ! k_0   at current T
-    kinf_T  = kinf_300K * zt_help**(m)        ! k_inf at current T
-    k_ratio = k0_T/kinf_T
-    k_3rd   = k0_T/(1._dp+k_ratio)*fc**(1._dp/(1._dp+LOG10(k_ratio)**2))
+    zt_help  = 300._dp/temp
+    k0_T     = k0_300K   * zt_help**(n) * cair ! k_0   at current T
+    kinf_T   = kinf_300K * zt_help**(m)        ! k_inf at current T
+    k_ratio  = k0_T/kinf_T
+    k_3rd_dp = k0_T/(1._dp+k_ratio)*fc**(1._dp/(1._dp+LOG10(k_ratio)**2))
 
-  END FUNCTION k_3rd
+  END FUNCTION k_3rd_dp
+
+  ELEMENTAL REAL(dp) FUNCTION k_3rd_sp(temp,cair,k0_300K,n,kinf_300K,m,fc)
+
+    INTRINSIC LOG10
+
+    REAL(dp), INTENT(IN) :: temp      ! temperature [K]
+    REAL(dp), INTENT(IN) :: cair      ! air concentration [molecules/cm3]
+    REAL(sp), INTENT(IN) :: k0_300K   ! low pressure limit at 300 K
+    REAL(sp), INTENT(IN) :: n         ! exponent for low pressure limit
+    REAL(sp), INTENT(IN) :: kinf_300K ! high pressure limit at 300 K
+    REAL(sp), INTENT(IN) :: m         ! exponent for high pressure limit
+    REAL(sp), INTENT(IN) :: fc        ! broadening factor (usually fc=0.6)
+    REAL(dp) :: zt_help, k0_T, kinf_T, k_ratio
+
+    zt_help  = 300._dp/temp
+    k0_T     = k0_300K   * zt_help**(n) * cair ! k_0   at current T
+    kinf_T   = kinf_300K * zt_help**(m)        ! k_inf at current T
+    k_ratio  = k0_T/kinf_T
+    k_3rd_sp = k0_T/(1._dp+k_ratio)*fc**(1._dp/(1._dp+LOG10(k_ratio)**2))
+
+  END FUNCTION k_3rd_sp
 
   ! --------------------------------------------------------------------------
 
-  PURE FUNCTION k_3rd_jpl_activation(temp,cair,k0_298K,n,kinf_298K,m,A,B)
+  PURE FUNCTION k_3rd_jpl_activation_dp(temp,cair,k0_298K,n,kinf_298K,m,A,B)
     ! JPL termolecular chemical activation reaction
-    
+
     INTRINSIC :: LOG10
-    REAL,   DIMENSION(2) :: k_3rd_jpl_activation
+    REAL(dp), DIMENSION(2) :: k_3rd_jpl_activation_dp
     REAL(dp), INTENT(IN) :: temp      ! temperature [K]
     REAL(dp), INTENT(IN) :: cair      ! air concentration [molecules/cm3]
-    REAL,     INTENT(IN) :: k0_298K   ! low pressure limit at 300 K
-    REAL,     INTENT(IN) :: n         ! exponent for low pressure limit
-    REAL,     INTENT(IN) :: kinf_298K ! high pressure limit at 300 K
-    REAL,     INTENT(IN) :: m         ! exponent for high pressure limit
-    REAL,     INTENT(IN) :: A         ! for k_int
-    REAL,     INTENT(IN) :: B         ! for k_int
+    REAL(dp), INTENT(IN) :: k0_298K   ! low pressure limit at 300 K
+    REAL(dp), INTENT(IN) :: n         ! exponent for low pressure limit
+    REAL(dp), INTENT(IN) :: kinf_298K ! high pressure limit at 300 K
+    REAL(dp), INTENT(IN) :: m         ! exponent for high pressure limit
+    REAL(dp), INTENT(IN) :: A         ! for k_int
+    REAL(dp), INTENT(IN) :: B         ! for k_int
     REAL                 :: zt_help, k0_TM, kinf_T, k_ratio, k_f, k_int, k_fCA
 
     zt_help = 298./temp
@@ -93,24 +175,51 @@
     k_f     = k0_TM/(1.+k_ratio)*0.6**(1./(1.+LOG10(k_ratio)**2))
     k_int   = A * exp(-B/temp)
     k_fCA   = k_int * (1. - k_f/kinf_T)
-    k_3rd_jpl_activation(ASSOC)  = k_f
-    k_3rd_jpl_activation(DISSOC) = k_fCA
-    
-  END FUNCTION k_3rd_jpl_activation
+    k_3rd_jpl_activation_dp(ASSOC)  = k_f
+    k_3rd_jpl_activation_dp(DISSOC) = k_fCA
+
+  END FUNCTION k_3rd_jpl_activation_dp
+
+  PURE FUNCTION k_3rd_jpl_activation_sp(temp,cair,k0_298K,n,kinf_298K,m,A,B)
+    ! JPL termolecular chemical activation reaction
+
+    INTRINSIC :: LOG10
+    REAL(sp), DIMENSION(2) :: k_3rd_jpl_activation_sp
+    REAL(dp), INTENT(IN) :: temp      ! temperature [K]
+    REAL(dp), INTENT(IN) :: cair      ! air concentration [molecules/cm3]
+    REAL(sp), INTENT(IN) :: k0_298K   ! low pressure limit at 300 K
+    REAL(sp), INTENT(IN) :: n         ! exponent for low pressure limit
+    REAL(sp), INTENT(IN) :: kinf_298K ! high pressure limit at 300 K
+    REAL(sp), INTENT(IN) :: m         ! exponent for high pressure limit
+    REAL(sp), INTENT(IN) :: A         ! for k_int
+    REAL(sp), INTENT(IN) :: B         ! for k_int
+    REAL                 :: zt_help, k0_TM, kinf_T, k_ratio, k_f, k_int, k_fCA
+
+    zt_help = 298./temp
+    k0_TM   = k0_298K   * zt_help**n * cair ! k_0   at current T * M
+    kinf_T  = kinf_298K * zt_help**m        ! k_inf at current T
+    k_ratio = k0_TM/kinf_T
+    k_f     = k0_TM/(1.+k_ratio)*0.6**(1./(1.+LOG10(k_ratio)**2))
+    k_int   = A * exp(-B/temp)
+    k_fCA   = k_int * (1. - k_f/kinf_T)
+    k_3rd_jpl_activation_sp(ASSOC)  = k_f
+    k_3rd_jpl_activation_sp(DISSOC) = k_fCA
+
+  END FUNCTION k_3rd_jpl_activation_sp
 
   ! --------------------------------------------------------------------------
 
-  ELEMENTAL REAL(dp) FUNCTION k_3rd_iupac(temp,cair,k0_300K,n,kinf_300K,m,fc)
+  ELEMENTAL REAL(dp) FUNCTION k_3rd_iupac_dp(temp,cair,k0_300K,n,kinf_300K,m,fc)
     ! IUPAC three body reaction formula (iupac.pole-ether.fr)
-    
+
     INTRINSIC :: LOG10
     REAL(dp), INTENT(IN) :: temp      ! temperature [K]
     REAL(dp), INTENT(IN) :: cair      ! air concentration [molecules/cm3]
-    REAL,     INTENT(IN) :: k0_300K   ! low pressure limit at 300 K
-    REAL,     INTENT(IN) :: n         ! exponent for low pressure limit
-    REAL,     INTENT(IN) :: kinf_300K ! high pressure limit at 300 K
-    REAL,     INTENT(IN) :: m         ! exponent for high pressure limit
-    REAL,     INTENT(IN) :: fc        ! broadening factor (e.g. 0.45 or 0.6...)
+    REAL(dp), INTENT(IN) :: k0_300K   ! low pressure limit at 300 K
+    REAL(dp), INTENT(IN) :: n         ! exponent for low pressure limit
+    REAL(dp), INTENT(IN) :: kinf_300K ! high pressure limit at 300 K
+    REAL(dp), INTENT(IN) :: m         ! exponent for high pressure limit
+    REAL(dp), INTENT(IN) :: fc        ! broadening factor (e.g. 0.45 or 0.6...)
     REAL                 :: nu        ! N
     REAL                 :: zt_help, k0_T, kinf_T, k_ratio
 
@@ -119,26 +228,64 @@
     kinf_T  = kinf_300K * zt_help**(m)        ! k_inf at current T
     k_ratio = k0_T/kinf_T
     nu      = 0.75-1.27*LOG10(fc)
-    k_3rd_iupac = k0_T/(1._dp+k_ratio)* &
+    k_3rd_iupac_dp = k0_T/(1._dp+k_ratio)* &
       fc**(1._dp/(1._dp+(LOG10(k_ratio)/nu)**2))
-    
-  END FUNCTION k_3rd_iupac
+
+  END FUNCTION k_3rd_iupac_dp
+
+  ELEMENTAL REAL(dp) FUNCTION k_3rd_iupac_sp(temp,cair,k0_300K,n,kinf_300K,m,fc)
+    ! IUPAC three body reaction formula (iupac.pole-ether.fr)
+
+    INTRINSIC :: LOG10
+    REAL(dp), INTENT(IN) :: temp      ! temperature [K]
+    REAL(dp), INTENT(IN) :: cair      ! air concentration [molecules/cm3]
+    REAL(sp), INTENT(IN) :: k0_300K   ! low pressure limit at 300 K
+    REAL(sp), INTENT(IN) :: n         ! exponent for low pressure limit
+    REAL(sp), INTENT(IN) :: kinf_300K ! high pressure limit at 300 K
+    REAL(sp), INTENT(IN) :: m         ! exponent for high pressure limit
+    REAL(sp), INTENT(IN) :: fc        ! broadening factor (e.g. 0.45 or 0.6...)
+    REAL                 :: nu        ! N
+    REAL                 :: zt_help, k0_T, kinf_T, k_ratio
+
+    zt_help = 300._dp/temp
+    k0_T    = k0_300K   * zt_help**(n) * cair ! k_0   at current T
+    kinf_T  = kinf_300K * zt_help**(m)        ! k_inf at current T
+    k_ratio = k0_T/kinf_T
+    nu      = 0.75-1.27*LOG10(fc)
+    k_3rd_iupac_sp = k0_T/(1._dp+k_ratio)* &
+      fc**(1._dp/(1._dp+(LOG10(k_ratio)/nu)**2))
+
+  END FUNCTION k_3rd_iupac_sp
 
   !---------------------------------------------------------------------------
 
-  ELEMENTAL REAL(dp) FUNCTION k_arr (k_298,tdep,temp)
+  ELEMENTAL REAL(dp) FUNCTION k_arr_dp (k_298,tdep,temp)
     ! Arrhenius function
 
-    REAL,     INTENT(IN) :: k_298 ! k at T = 298.15K
-    REAL,     INTENT(IN) :: tdep  ! temperature dependence
+    REAL(dp), INTENT(IN) :: k_298 ! k at T = 298.15K
+    REAL(dp), INTENT(IN) :: tdep  ! temperature dependence
     REAL(dp), INTENT(IN) :: temp  ! temperature
 
     INTRINSIC EXP
 
-    k_arr = k_298 * EXP(tdep*(1._dp/temp-3.3540E-3_dp)) ! 1/298.15=3.3540e-3
+    k_arr_dp = k_298 * EXP(tdep*(1._dp/temp-3.3540E-3_dp)) ! 1/298.15=3.3540e-3
 
-  END FUNCTION k_arr
+  END FUNCTION k_arr_dp
 
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ELEMENTAL REAL(dp) FUNCTION k_arr_sp (k_298,tdep,temp)
+    ! Arrhenius function
+
+    REAL(sp), INTENT(IN) :: k_298 ! k at T = 298.15K
+    REAL(sp), INTENT(IN) :: tdep  ! temperature dependence
+    REAL(dp), INTENT(IN) :: temp  ! temperature
+
+    INTRINSIC EXP
+
+    k_arr_sp = k_298 * EXP(tdep*(1._dp/temp-3.3540E-3_dp)) ! 1/298.15=3.3540e-3
+
+  END FUNCTION k_arr_sp
+
+
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !  End of User-defined Rate Law functions
-!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/util/UserRateLawsInterfaces.f90
+++ b/util/UserRateLawsInterfaces.f90
@@ -1,0 +1,53 @@
+  PRIVATE :: ARR_dp, ARR_sp
+  INTERFACE ARR
+     MODULE PROCEDURE ARR_dp
+     MODULE PROCEDURE ARR_sp
+  END INTERFACE ARR
+
+  PRIVATE :: ARR2_dp, ARR2_sp
+  INTERFACE ARR2
+     MODULE PROCEDURE ARR2_dp
+     MODULE PROCEDURE ARR2_sp
+  END INTERFACE ARR2
+
+  PRIVATE :: EP2_dp, EP2_sp
+  INTERFACE EP2
+     MODULE PROCEDURE EP2_dp
+     MODULE PROCEDURE EP2_sp
+  END INTERFACE EP2
+
+  PRIVATE :: EP3_dp, EP3_sp
+  INTERFACE EP3
+     MODULE PROCEDURE EP3_dp
+     MODULE PROCEDURE EP3_sp
+  END INTERFACE EP3
+
+  PRIVATE :: FALL_dp, FALL_sp
+  INTERFACE FALL
+     MODULE PROCEDURE FALL_dp
+     MODULE PROCEDURE FALL_sp
+  END INTERFACE FALL
+
+  PRIVATE :: k_3rd_dp, k_3rd_sp
+  INTERFACE k_3rd
+     MODULE PROCEDURE k_3rd_dp
+     MODULE PROCEDURE k_3rd_sp
+  END INTERFACE k_3rd
+
+  PRIVATE :: k_3rd_jpl_activation_dp, k_3rd_jpl_activation_sp
+  INTERFACE  k_3rd_jpl_activation
+     MODULE PROCEDURE  k_3rd_jpl_activation_dp
+     MODULE PROCEDURE  k_3rd_jpl_activation_sp
+  END INTERFACE  k_3rd_jpl_activation
+
+  PRIVATE :: k_3rd_iupac_dp, k_3rd_iupac_sp
+  INTERFACE k_3rd_iupac
+     MODULE PROCEDURE k_3rd_iupac_dp
+     MODULE PROCEDURE k_3rd_iupac_sp
+  END INTERFACE k_3rd_iupac
+
+  PRIVATE :: k_arr_dp, k_arr_sp
+  INTERFACE k_arr
+     MODULE PROCEDURE k_arr_dp
+     MODULE PROCEDURE k_arr_sp
+  END INTERFACE k_arr


### PR DESCRIPTION
This PR modifies the rate-law functions in `util/UserRateLaws.f90` as follows:

Each rate law function such as `ARR`:
```F90
   KPP_REAL FUNCTION ARR( A0,B0,C0 )
      REAL A0,B0,C0      
      ARR =  DBLE(A0) * EXP(-DBLE(B0)/TEMP) * (TEMP/300.0_dp)**DBLE(C0)
   END FUNCTION ARR

  ... etc ...
```
Has now been split into 2 rate-law functions: one that takes single-precision arguments and one that takes double-precision arguments:
```F90
  FUNCTION ARR_dp( a0, b0, c0 ) RESULT( k )
    ! Arrhenius function (dp args)
    REAL(dp), INTENT(IN) :: a0, b0, c0
    REAL(dp)             :: k
    k =  a0 * EXP(-b0/TEMP) * (TEMP/300.0_dp)**C0
  END FUNCTION ARR_dp

  FUNCTION ARR_sp( a0, b0, c0 ) RESULT( k )
    ! Arrhenius function (sp args)
    REAL(sp) :: a0, b0, c0
    REAL(dp) :: k
    k =  DBLE(a0) * EXP(-DBLE(b0)/TEMP) * (TEMP/300.0_dp)**DBLE(c0)
  END FUNCTION ARR_sp

  ... etc ...
```
This allows us to remove the calls to `DBLE()` in the functions that take double-precision arguments (which avoids unnecessary CPU cycles).

A new include file `util/UserRateLawsInterfaces.f90` has also been introduced.  This contains the `INTERFACE` statements that overload the separate single-precision and double-precision functions.  These interfaces have to be placed into a separate file so that they can be inlined into the `KPP_ROOT_Rates` module file above the 'CONTAINS` statement:

```F90
  PRIVATE :: ARR_dp, ARR_sp
  INTERFACE ARR
     MODULE PROCEDURE ARR_dp
     MODULE PROCEDURE ARR_sp
  END INTERFACE ARR

  ... etc ...
```

Running C-I tests on this branch gives identical results to C-I tests run on the `cleanup_int` branch.

**NOTE:** I have the target branch for this PR as `cleanup_int`.  After we merge this into `cleanup_int` we should be able to merge `cleanup_int` into `dev`.