### PR TITLE
Cleanup in auto-reduce code and add CI tests

### DIFF
--- a/.ci-pipelines/ci-manual-cleanup-script.sh
+++ b/.ci-pipelines/ci-manual-cleanup-script.sh
@@ -6,7 +6,7 @@
 ########################################################################
 
 # List of tests (add more as necessary; separate each with a space)
-all_tests="radau90 rk rktlm ros ros_split rosadj rosenbrock90 rostlm saprc2006 sd sdadj small_f90 ros_upcase ros_minver small_strato seulex90"
+all_tests="radau90 rk rktlm ros ros_split rosadj rosenbrock90 rostlm saprc2006 sd sdadj small_f90 ros_upcase ros_minver small_strato seulex90 ros_autoreduce"
 
 # Current directory
 this_dir=$(pwd -P)

--- a/.ci-pipelines/ci-manual-testing-script.sh
+++ b/.ci-pipelines/ci-manual-testing-script.sh
@@ -6,7 +6,7 @@
 ########################################################################
 
 # List of tests (add more as necessary; separate each with a space)
-all_tests="radau90 rk rktlm ros ros_split rosadj rosenbrock90 rostlm saprc2006 sd sdadj small_f90 ros_upcase small_strato seulex90"
+all_tests="radau90 rk rktlm ros ros_split rosadj rosenbrock90 rostlm saprc2006 sd sdadj small_f90 ros_upcase small_strato seulex90 ros_autoreduce"
 
 # Run each test
 # Check status of each individual operation and exit if any do not complete

--- a/.ci-pipelines/ci-testing-script.sh
+++ b/.ci-pipelines/ci-testing-script.sh
@@ -5,7 +5,7 @@
 ########################################################################
 
 # List of tests (add more as necessary; separate each with a space)
-all_tests="radau90 rk rktlm ros rosadj rosenbrock90 rostlm saprc2006 sd sdadj small_f90 ros_upcase small_strato seulex90"
+all_tests="radau90 rk rktlm ros rosadj rosenbrock90 rostlm saprc2006 sd sdadj small_f90 ros_upcase small_strato seulex90 ros_autoreduce"
 
 # Run each test
 # Check status of each individual operation and exit if any do not complete

--- a/ci-tests/ros_autoreduce/ros_autoreduce.kpp
+++ b/ci-tests/ros_autoreduce/ros_autoreduce.kpp
@@ -1,0 +1,5 @@
+#MODEL      saprc99
+#INTEGRATOR rosenbrock_autoreduce
+#AUTOREDUCE on
+#LANGUAGE   Fortran90
+#DRIVER     general_autoreduce

--- a/drv/general_autoreduce.f90
+++ b/drv/general_autoreduce.f90
@@ -1,0 +1,81 @@
+PROGRAM KPP_ROOT_Driver
+
+!~~~> Global variables and routines
+      USE KPP_ROOT_Model
+      USE KPP_ROOT_Initialize, ONLY: Initialize
+
+!~~~> Local variables
+      KPP_REAL :: T, DVAL(NSPEC)
+      KPP_REAL :: RSTATE(20)
+      INTEGER :: i
+
+!~~~> Control (in) arguments for the integration
+!~~~> These are set to zero by default, which will invoke default behavior
+      INTEGER :: ICNTRL(20)
+      KPP_REAL :: RCNTRL(20)
+
+      ICNTRL  = 0
+      RCNTRL  = 0.d0
+
+!~~~> Initialization
+      STEPMIN = 0.0d0
+      STEPMAX = 0.0d0
+
+      DO i=1,NVAR
+        RTOL(i) = 1.0d-4
+        ATOL(i) = 1.0d-3
+      END DO
+
+!~~~> Enable auto-reduction
+      ICNTRL(12) = 1
+      RCNTRL(12) = 1000.0d0
+      ! ICNTRL(14) = 74
+      ! RCNTRL(14) = 1e-4
+
+!~~~> Set default species concentrations
+      CALL Initialize()
+
+!~~~> Open log file for write
+      CALL InitSaveData()
+
+!~~~> Time loop
+      T = TSTART
+kron: DO WHILE (T < TEND)
+
+        TIME = T
+
+!~~~> Write values of monitored species at each iteration
+        CALL GetMass( C, DVAL )
+        WRITE(6,991) (T-TSTART)/(TEND-TSTART)*100, T,       &
+                   ( TRIM(SPC_NAMES(MONITOR(i))),           &
+                     C(MONITOR(i))/CFACTOR, i=1,NMONITOR )
+        CALL SaveData()
+
+!~~~> Update sunlight intensity and reaction rates
+!~~~> before calling the integrator.
+        CALL Update_SUN()
+        CALL Update_RCONST()
+
+!~~~> Call the integrator
+        CALL INTEGRATE( TIN       = T,        &
+                        TOUT      = T+DT,     &
+                        ICNTRL_U  = ICNTRL,   &
+                        RCNTRL_U  = RCNTRL,   &
+                        RSTATUS_U = RSTATE   )
+        T = RSTATE(1)
+
+      END DO kron
+!~~~> End Time loop
+
+!~~~> Write final values of monitored species and close log file
+      CALL GetMass( C, DVAL )
+      WRITE(6,991) (T-TSTART)/(TEND-TSTART)*100, T,     &
+               ( TRIM(SPC_NAMES(MONITOR(i))),           &
+                 C(MONITOR(i))/CFACTOR, i=1,NMONITOR )
+      TIME = T
+      CALL SaveData()
+      CALL CloseSaveData()
+
+991   FORMAT(F6.1,'%. T=',E9.3,2X,200(A,'=',E11.4,'; '))
+
+END PROGRAM KPP_ROOT_Driver

--- a/int/rosenbrock_autoreduce.f90
+++ b/int/rosenbrock_autoreduce.f90
@@ -298,7 +298,7 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
    INTEGER       :: i, UplimTol, Max_no_steps
    LOGICAL       :: Autonomous, VectorTol, Autoreduce, Autoreduce_Append
    INTEGER       :: AR_target_spc
-   REAL(kind=dp) :: AR_thr_ratio
+   KPP_REAL :: AR_thr_ratio
 !~~~>   Parameters
    KPP_REAL, PARAMETER :: ZERO = 0.0_dp, ONE  = 1.0_dp
    KPP_REAL, PARAMETER :: DeltaMin = 1.0E-5_dp
@@ -781,44 +781,44 @@ Stage: DO istage = 1, ros_S
   IMPLICIT NONE
 
 !~~~> Input: the initial condition at Tstart; Output: the solution at T
-   REAL(kind=dp), INTENT(INOUT) :: Y(N)
+   KPP_REAL, INTENT(INOUT) :: Y(N)
 !~~~> Input: integration interval
-   REAL(kind=dp), INTENT(IN) :: Tstart,Tend
+   KPP_REAL, INTENT(IN) :: Tstart,Tend
 !~~~> Output: time at which the solution is returned (T=Tend if success)
-   REAL(kind=dp), INTENT(OUT) ::  T
+   KPP_REAL, INTENT(OUT) ::  T
 !~~~> Input: tolerances
-   REAL(kind=dp), INTENT(IN) ::  AbsTol(N), RelTol(N)
+   KPP_REAL, INTENT(IN) ::  AbsTol(N), RelTol(N)
 !~~~> Input: integration parameters
    LOGICAL, INTENT(IN) :: Autonomous, VectorTol
-   REAL(kind=dp), INTENT(IN) :: Hstart, Hmin, Hmax
+   KPP_REAL, INTENT(IN) :: Hstart, Hmin, Hmax
    INTEGER, INTENT(IN) :: Max_no_steps
-   REAL(kind=dp), INTENT(IN) :: Roundoff, FacMin, FacMax, FacRej, FacSafe
+   KPP_REAL, INTENT(IN) :: Roundoff, FacMin, FacMax, FacRej, FacSafe
 !~~~> Autoreduction threshold
-   REAL(kind=dp), INTENT(IN) :: threshold
+   KPP_REAL, INTENT(IN) :: threshold
 !~~~> Output: Error indicator
    INTEGER, INTENT(OUT) :: IERR
 ! ~~~~ Local variables
-   REAL(kind=dp) :: Ynew(N), Fcn0(N), Fcn(N), Prod(N), Loss(N), LossY(N)
-   REAL(kind=dp) :: K(NVAR*ros_S), dFdT(N)
+   KPP_REAL :: Ynew(N), Fcn0(N), Fcn(N), Prod(N), Loss(N), LossY(N)
+   KPP_REAL :: K(NVAR*ros_S), dFdT(N)
 #ifdef FULL_ALGEBRA
-   REAL(kind=dp) :: Jac0(N,N), Ghimj(N,N)
+   KPP_REAL :: Jac0(N,N), Ghimj(N,N)
 #else
-   REAL(kind=dp) :: Jac0(LU_NONZERO), Ghimj(LU_NONZERO)
-   REAL(kind=dp) :: cGhimj(LU_NONZERO) ! not known at this point what cNONZERO will be
+   KPP_REAL :: Jac0(LU_NONZERO), Ghimj(LU_NONZERO)
+   KPP_REAL :: cGhimj(LU_NONZERO) ! not known at this point what cNONZERO will be
 #endif
-   REAL(kind=dp) :: H, Hnew, HC, HG, Fac, Tau
-   REAL(kind=dp) :: Err, Yerr(N), Yerrsub(NVAR)
+   KPP_REAL :: H, Hnew, HC, HG, Fac, Tau
+   KPP_REAL :: Err, Yerr(N), Yerrsub(NVAR)
    INTEGER :: Pivot(N), Direction, ioffset, j, istage
    LOGICAL :: RejectLastH, RejectMoreH, Singular, Reduced
 !~~~>  Local parameters
-   REAL(kind=dp), PARAMETER :: ZERO = 0.0_dp, ONE  = 1.0_dp
-   REAL(kind=dp), PARAMETER :: DeltaMin = 1.0E-5_dp
+   KPP_REAL, PARAMETER :: ZERO = 0.0_dp, ONE  = 1.0_dp
+   KPP_REAL, PARAMETER :: DeltaMin = 1.0E-5_dp
    INTEGER :: SPC
-   REAL(kind=dp) :: alpha_factor ! hplin 4/10/22
+   KPP_REAL :: alpha_factor ! hplin 4/10/22
 !      Inline local parameters for AR.
    INTEGER :: II, III, idx, nrmv, s
-   REAL(kind=dp), INTENT(IN) :: AR_thr_ratio
-   REAL(kind=dp) :: AR_thr
+   KPP_REAL, INTENT(IN) :: AR_thr_ratio
+   KPP_REAL :: AR_thr
    INTEGER, INTENT(IN) :: AR_target_spc
 !~~~>  Initial preparations
    DO_SLV  = .true.
@@ -1234,44 +1234,44 @@ Stage: DO istage = 1, ros_S
   IMPLICIT NONE
 
 !~~~> Input: the initial condition at Tstart; Output: the solution at T
-   REAL(kind=dp), INTENT(INOUT) :: Y(N)
+   KPP_REAL, INTENT(INOUT) :: Y(N)
 !~~~> Input: integration interval
-   REAL(kind=dp), INTENT(IN) :: Tstart,Tend
+   KPP_REAL, INTENT(IN) :: Tstart,Tend
 !~~~> Output: time at which the solution is returned (T=Tend if success)
-   REAL(kind=dp), INTENT(OUT) ::  T
+   KPP_REAL, INTENT(OUT) ::  T
 !~~~> Input: tolerances
-   REAL(kind=dp), INTENT(IN) ::  AbsTol(N), RelTol(N)
+   KPP_REAL, INTENT(IN) ::  AbsTol(N), RelTol(N)
 !~~~> Input: integration parameters
    LOGICAL, INTENT(IN) :: Autonomous, VectorTol
-   REAL(kind=dp), INTENT(IN) :: Hstart, Hmin, Hmax
+   KPP_REAL, INTENT(IN) :: Hstart, Hmin, Hmax
    INTEGER, INTENT(IN) :: Max_no_steps
-   REAL(kind=dp), INTENT(IN) :: Roundoff, FacMin, FacMax, FacRej, FacSafe
+   KPP_REAL, INTENT(IN) :: Roundoff, FacMin, FacMax, FacRej, FacSafe
 !~~~> Autoreduction threshold
-   REAL(kind=dp), INTENT(IN) :: threshold
+   KPP_REAL, INTENT(IN) :: threshold
 !~~~> Output: Error indicator
    INTEGER, INTENT(OUT) :: IERR
 ! ~~~~ Local variables
-   REAL(kind=dp) :: Ynew(N), Fcn0(N), Fcn(N), Prod(N), Loss(N), LossY(N), Prd0(N), Los0(N)
-   REAL(kind=dp) :: K(NVAR*ros_S), dFdT(N)
+   KPP_REAL :: Ynew(N), Fcn0(N), Fcn(N), Prod(N), Loss(N), LossY(N), Prd0(N), Los0(N)
+   KPP_REAL :: K(NVAR*ros_S), dFdT(N)
 #ifdef FULL_ALGEBRA
-   REAL(kind=dp) :: Jac0(N,N), Ghimj(N,N)
+   KPP_REAL :: Jac0(N,N), Ghimj(N,N)
 #else
-   REAL(kind=dp) :: Jac0(LU_NONZERO), Ghimj(LU_NONZERO)
-   REAL(kind=dp) :: cGhimj(LU_NONZERO) ! not known at this point what cNONZERO will be
+   KPP_REAL :: Jac0(LU_NONZERO), Ghimj(LU_NONZERO)
+   KPP_REAL :: cGhimj(LU_NONZERO) ! not known at this point what cNONZERO will be
 #endif
-   REAL(kind=dp) :: H, Hnew, HC, HG, Fac, Tau
-   REAL(kind=dp) :: Err, Yerr(N), Yerrsub(NVAR)
+   KPP_REAL :: H, Hnew, HC, HG, Fac, Tau
+   KPP_REAL :: Err, Yerr(N), Yerrsub(NVAR)
    INTEGER :: Pivot(N), Direction, ioffset, j, istage
    LOGICAL :: RejectLastH, RejectMoreH, Singular, Reduced
 !~~~>  Local parameters
-   REAL(kind=dp), PARAMETER :: ZERO = 0.0_dp, ONE  = 1.0_dp
-   REAL(kind=dp), PARAMETER :: DeltaMin = 1.0E-5_dp
+   KPP_REAL, PARAMETER :: ZERO = 0.0_dp, ONE  = 1.0_dp
+   KPP_REAL, PARAMETER :: DeltaMin = 1.0E-5_dp
    INTEGER :: SPC
-   REAL(kind=dp) :: alpha_factor ! hplin 4/10/22
+   KPP_REAL :: alpha_factor ! hplin 4/10/22
 !      Inline local parameters for AR.
    INTEGER :: II, III, idx, nrmv, s
-   REAL(kind=dp), INTENT(IN) :: AR_thr_ratio
-   REAL(kind=dp) :: AR_thr
+   KPP_REAL, INTENT(IN) :: AR_thr_ratio
+   KPP_REAL :: AR_thr
    INTEGER, INTENT(IN) :: AR_target_spc
 !~~~>  Initial preparations
    DO_SLV  = .true.
@@ -1666,10 +1666,10 @@ Stage: DO istage = 1, ros_S
  END SUBROUTINE ros_yIntegratorA
 
  SUBROUTINE AutoReduce_1stOrder(i,Y,P,k,Ti,Tf)
-   REAL(kind=dp), INTENT(INOUT) :: Y
-   REAL(kind=dp), INTENT(IN)    :: P,k,Ti,Tf
+   KPP_REAL, INTENT(INOUT) :: Y
+   KPP_REAL, INTENT(IN)    :: P,k,Ti,Tf
    INTEGER, INTENT(IN)          :: i
-   REAL(kind=dp)                :: term
+   KPP_REAL                :: term
 
    if (k .le. 1.d-30) return
    if (Y .le. 1.d-30) return
@@ -2492,12 +2492,12 @@ SUBROUTINE FunSplitF( T, Y, Ydot, P_VAR, D_VAR, DY_VAR )
  USE KPP_ROOT_Global, ONLY: FIX, RCONST, TIME
  USE KPP_ROOT_Function, ONLY: Fun_SPLITF
 !~~~> Input variables
-   REAL(kind=dp) :: T, Y(NVAR)
+   KPP_REAL :: T, Y(NVAR)
 !~~~> Output variables
-   REAL(kind=dp) :: Ydot(NVAR)
-   REAL(kind=dp) :: P_VAR(NVAR), D_VAR(NVAR), DY_VAR(NVAR)
+   KPP_REAL :: Ydot(NVAR)
+   KPP_REAL :: P_VAR(NVAR), D_VAR(NVAR), DY_VAR(NVAR)
 !~~~> Local variables
-   REAL(kind=dp) :: Told, P(NVAR), D(NVAR)
+   KPP_REAL :: Told, P(NVAR), D(NVAR)
    P    = 0.d0
    D    = 0.d0
    Told = TIME
@@ -2523,12 +2523,12 @@ SUBROUTINE FunSplitN( T, Y, Ydot)
  USE KPP_ROOT_Global, ONLY: FIX, RCONST, TIME
  USE KPP_ROOT_Function, ONLY: Fun_SPLITF
 !~~~> Input variables
-   REAL(kind=dp) :: T, Y(NVAR)
+   KPP_REAL :: T, Y(NVAR)
 !~~~> Output variables
-   REAL(kind=dp) :: Ydot(NVAR)
-   REAL(kind=dp) :: P_VAR(NVAR), D_VAR(NVAR)
+   KPP_REAL :: Ydot(NVAR)
+   KPP_REAL :: P_VAR(NVAR), D_VAR(NVAR)
 !~~~> Local variables
-   REAL(kind=dp) :: Told, P(NVAR), D(NVAR)
+   KPP_REAL :: Told, P(NVAR), D(NVAR)
 
    P    = 0.d0
    D    = 0.d0
@@ -2625,142 +2625,6 @@ SUBROUTINE cKppDecomp( JVS, IER )
       END DO
       
 END SUBROUTINE cKppDecomp
-
-!--------------------------------------------------------------
-SUBROUTINE cWAXPY(N,Alpha,X,incX,Y,incY,fN,indx)
-!--------------------------------------------------------------
-!     constant times a vector plus a vector: y <- y + Alpha*x
-!     only for incX=incY=1
-!     after BLAS
-!     replace this by the function from the optimized BLAS implementation:
-!         CALL SAXPY(N,Alpha,X,1,Y,1) or  CALL DAXPY(N,Alpha,X,1,Y,1)
-!
-!     Revision:
-!     -- Aug. 27, 2021: Added fN and indx as arguments to permit 
-!        subsetting Y as required to preserve the length of Y 
-!        and minimze array copying.
-!--------------------------------------------------------------
-
-  INTEGER  :: i,incX,incY,M,MP1,N,fN,indx(N)
-  KPP_REAL :: X(N),Y(fN),Alpha
-  KPP_REAL, PARAMETER :: ZERO = 0.0_dp
-  
-  IF (Alpha .EQ. ZERO) RETURN
-  IF (N .LE. 0) RETURN
-  
-  M = MOD(N,4)
-  IF( M .NE. 0 ) THEN
-     DO i = 1,M
-        Y(indx(i)) = Y(indx(i)) + Alpha*X(i)
-     END DO
-     IF( N .LT. 4 ) RETURN
-  END IF
-  MP1 = M + 1
-  DO i = MP1,N,4
-     Y(indx(i))     = Y(indx(i)) + Alpha*X(i)
-     Y(indx(i + 1)) = Y(indx(i + 1)) + Alpha*X(i + 1)
-     Y(indx(i + 2)) = Y(indx(i + 2)) + Alpha*X(i + 2)
-     Y(indx(i + 3)) = Y(indx(i + 3)) + Alpha*X(i + 3)
-  END DO
-  
-END SUBROUTINE cWAXPY
-
-! Unoptimized version
-SUBROUTINE REDUCE(threshold,P,L,IERR)
-  USE KPP_ROOT_JacobianSP
-
-  REAL(dp), INTENT(IN) :: P(NVAR), L(NVAR), threshold
-!        INTEGER              :: iSPC_MAP(NVAR)
-  INTEGER              :: i, ii, iii, idx, nrmv, s
-  INTEGER              :: IERR
-  LOGICAL              :: SKIP
-
-  iSPC_MAP = 0
-  NRMV = 0
-  S    = 1
-
-  ! If all species will be deactivated, just to 1st order approx
-  ! hplin: patch this out ... maxval is very expensive here
-  ! if (maxval(P) .lt. threshold .and. maxval(L) .lt. threshold .and. .not. keepActive) then
-  !    IERR = -98
-  !    return
-  ! endif
-
-  ! Checks should be kept out of tight inner loops.
-  IF(keepActive) THEN
-   DO i=1,NVAR
-     ! Short-circuiting using SKIP is very important here.
-     if (.not. keepSpcActive(i) .and. &
-         abs(L(i)).lt.threshold .and. abs(P(i)).lt.threshold) then ! per Shen et al., 2020
-        NRMV=NRMV+1
-        RMV(NRMV) = i
-        DO_SLV(i) = .false.
-        DO_FUN(i) = .false.
-        cycle
-     endif
-     SPC_MAP(S)  = i ! Add to full spc map.
-     iSPC_MAP(i) = S
-     S=S+1
-   ENDDO
-  ENDIF
-
-  IF (.not. keepActive) THEN
-    DO i=1,NVAR
-     ! Short-circuiting using SKIP is very important here.
-     if (abs(L(i)).lt.threshold .and. abs(P(i)).lt.threshold) then ! per Shen et al., 2020
-        NRMV=NRMV+1
-        RMV(NRMV) = i
-        DO_SLV(i) = .false.
-        DO_FUN(i) = .false.
-        cycle
-     endif
-     SPC_MAP(S)  = i ! Add to full spc map.
-     iSPC_MAP(i) = S
-     S=S+1
-   ENDDO
-  ENDIF
-
-  rNVAR    = NVAR-NRMV ! Number of active species in the reduced mechanism
-
-  ! Problem size cut-off. If problem is greater than some fraction of the
-  ! full, just solve the full (via error value) -- MSL
-  ! if (dble(rNVAR)/dble(NVAR) .ge. 1.1) then ! Set to 1.1 to deactive it. The results can't be > 1
-  !    IERR = -99
-  !    return
-  ! endif
-
-  II  = 1
-  III = 1
-  idx = 0
-  DO i = 1,LU_NONZERO
-     IF ((DO_SLV(LU_IROW(i))).and.(DO_SLV(LU_ICOL(i)))) THEN
-        idx=idx+1 ! counter for the number of non-zero elements in the reduced Jacobian
-        cLU_IROW(idx) = iSPC_MAP(LU_IROW(i))
-        cLU_ICOL(idx) = iSPC_MAP(LU_ICOL(i))
-        JVS_MAP(idx)  = i
-        
-        IF (idx.gt.1) THEN
-           IF (cLU_IROW(idx).ne.cLU_IROW(idx-1)) THEN
-              II=II+1
-              cLU_CROW(II) = idx
-           ENDIF
-           IF (cLU_IROW(idx).eq.cLU_ICOL(idx)) THEN
-              III=III+1
-              cLU_DIAG(III) = idx
-           ENDIF
-        ENDIF
-        cycle
-     ENDIF
-     DO_JVS(i) = .false.
-  ENDDO
-
-  cNONZERO = idx
-
-  cLU_CROW(1)       = 1 ! 1st index = 1
-  cLU_DIAG(1)       = 1 ! 1st index = 1
-  cLU_CROW(rNVAR+1) = cNONZERO+1
-  cLU_DIAG(rNVAR+1) = cLU_DIAG(rNVAR)+1
-END SUBROUTINE REDUCE
 
 SUBROUTINE APPEND(IDX)
   USE KPP_ROOT_JacobianSP


### PR DESCRIPTION
This PR replaces `REAL(kind=dp)` in `rosenbrock_autoreduce` with `KPP_REAL` for consistency with other integrators.

I also added a new driver `general_autoreduce` and added a CI test `ros_autoreduce` which uses the auto-reduction integrator. Interestingly, it runs slower than the regular `ros` for some reason. The test is only to make sure the integrator isn't broken in future releases - tests of the AR integrator for science should still use the box model developed by @msl3v here https://github.com/KineticPreProcessor/KPP-AR-boxmodel