### PR TITLE
GenerateJacReactantProd(): change arrays from static allocation to dynamic

### DIFF
--- a/src/gen.c
+++ b/src/gen.c
@@ -1071,8 +1071,8 @@ void GenerateJacReactantProd()
 {
 int i, j, k, l, m, JVRP_NZ, newrow;
 int F_STOIC;
-int crow_JVRP[MAX_EQN], icol_JVRP[MAX_EQN*MAX_SPECIES];
-int irow_JVRP[MAX_EQN*MAX_SPECIES];
+int crow_JVRP[EqnNr], icol_JVRP[EqnNr*VarNr];
+int irow_JVRP[EqnNr*VarNr];
 
   if( VarNr == 0 ) return;
 


### PR DESCRIPTION
I might have a potential solution for this issue: https://github.com/KineticPreProcessor/KPP/issues/64

The segfault doesn't occur in the generation of the sparse stoichiometric matrix, but in the call to GenerateJacReactantProd().  Switching a few static arrays to be smaller, dynamic arrays (that are allocated in a heap) fixed the stack overflow problem on my Mac.

Setting ulimit -s unlimited on my Mac sets the stacksize to 65520 KB, which seems like a hard limit for my system. This isn't enough, on a Linux system I tried, small strato needed a stacksize of 486208 KB to run with #STOICMAT ON. If this is a valid fix, it might be relevant for Linux users as well as Mac users: maybe the STOICMAT option doesn't need a huge stacksize.  
