### PR TITLE
Update citation for KPP 3.0.0 paper

### DIFF
--- a/docs/source/citations/kpp.bib
+++ b/docs/source/citations/kpp.bib
@@ -438,7 +438,9 @@
                   chemistry models: implementation and evaluation within
                   the Kinetic Pre-Processor ({KPP}) version 3.0.0},
  journal      = james,
- year         = {submitted, 2022}
+ pages        = {2022MS003293},
+ doi          = {10.1029/2022MS003293},
+ year         = {2023}
 }
 
 @ARTICLE{Sandu_and_Sander_2006,


### PR DESCRIPTION
Hi all, this is just a simple update to the RTD documentation to reflect the published citation for the KPP 3.0.0 paper.

We may have to sync this to `main` as well, since kpp.readthedocs.io points to stable by default.

Thanks!
Haipeng