### PR TITLE
Add `CITATION.cff`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,7 +44,7 @@ identifiers:
     value: 10.1029/2022MS003293
     description: Paper
   - type: doi
-    value: 10.5281/zenodo.6563908
+    value: 10.5281/zenodo.6828025
     description: Code archive (Zenodo)
 repository-code: 'https://github.com/KineticPreProcessor/KPP'
 url: 'https://kpp.readthedocs.io'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,109 @@
+cff-version: 1.2.0
+title: 'The Kinetic PreProcessor: KPP'
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Adrian
+    family-names: Sandu
+    affiliation: >-
+      Virginia Polytechnic Institute and State University,
+      Blacksburg, VA, USA
+  - given-names: Rolf
+    family-names: Sander
+    affiliation: 'Max-Planck Institute for Chemistry, Mainz, Germany'
+  - given-names: Michael S.
+    family-names: Long
+    affiliation: 'Renaissance Fiber, LLC, NC, USA'
+  - given-names: Haipeng
+    family-names: Lin
+    affiliation: >-
+      Harvard John A. Paulson School of Engineering and
+      Applied Sciences, Cambridge, MA, USA
+  - given-names: Robert M.
+    family-names: Yantosca
+    affiliation: >-
+      Harvard John A. Paulson School of Engineering and
+      Applied Sciences, Cambridge, MA, USA
+  - given-names: Lucas
+    family-names: Estrada
+    affiliation: >-
+      Harvard John A. Paulson School of Engineering and
+      Applied Sciences, Cambridge, MA, USA
+  - given-names: Lu
+    family-names: Shen
+    affiliation: 'School of Physics, Peking University, Bejing, China'
+  - given-names: Daniel J.
+    family-names: Jacob
+    affiliation: >-
+      Harvard John A. Paulson School of Engineering and
+      Applied Sciences, Cambridge, MA, USA
+identifiers:
+  - type: doi
+    value: 10.1029/2022MS003293
+    description: Paper
+  - type: doi
+    value: 10.5281/zenodo.6563908
+    description: Code archive (Zenodo)
+repository-code: 'https://github.com/KineticPreProcessor/KPP'
+url: 'https://kpp.readthedocs.io'
+abstract: >-
+  The KPP kinetic preprocessor is a software tool that
+  assists the computer simulation of chemical kinetic
+  systems.
+keywords:
+  - chemistry
+  - chemical-solver
+  - numerical-methods
+  - atmospheric-chemistry
+  - scientific-computing
+license: GPL-3.0
+preferred-citation:
+  type: article
+  authors:
+    - given-names: Haipeng
+      family-names: Lin
+      affiliation: >-
+        Harvard John A. Paulson School of Engineering and
+        Applied Sciences, Cambridge, MA, USA
+    - given-names: Michael S.
+      family-names: Long
+      affiliation: 'Renaissance Fiber, LLC, NC, USA'
+    - given-names: Rolf
+      family-names: Sander
+      affiliation: 'Max-Planck Institute for Chemistry, Mainz, Germany'
+    - given-names: Adrian
+      family-names: Sandu
+      affiliation: >-
+        Virginia Polytechnic Institute and State University,
+        Blacksburg, VA, USA
+    - given-names: Robert M.
+      family-names: Yantosca
+      affiliation: >-
+        Harvard John A. Paulson School of Engineering and
+        Applied Sciences, Cambridge, MA, USA
+    - given-names: Lucas
+      family-names: Estrada
+      affiliation: >-
+        Harvard John A. Paulson School of Engineering and
+        Applied Sciences, Cambridge, MA, USA
+    - given-names: Lu
+      family-names: Shen
+      affiliation: 'School of Physics, Peking University, Bejing, China'
+    - given-names: Daniel J.
+      family-names: Jacob
+      affiliation: >-
+        Harvard John A. Paulson School of Engineering and
+        Applied Sciences, Cambridge, MA, USA
+  title: >-
+    An adaptive auto-reduction solver for speeding up
+    integration of chemical kinetics in atmospheric
+    chemistry models: implementation and evaluation within
+    the Kinetic Pre-Processor (KPP) version 3.0.0
+  journal: JAMES
+  year: 2023
+  month: 2
+  volume: 15
+  issue: 2
+  doi: 10.1029/2022MS003293

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Latest
 Release](https://img.shields.io/github/v/release/KineticPreProcessor/KPP?label=Latest%20Release)](https://kpp.readthedocs.io) [![License: GPL
 v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://github.com/KineticPreProcessor/KPP/blob/main/LICENSE.txt) [![C-I
-tests](https://img.shields.io/azure-devops/build/KineticPreProcessor/KPP/1/main?label=C-I%20Tests)](https://dev.azure.com/KineticPreProcessor/KPP/_build) [![ReadTheDocs](https://assets.readthedocs.org/static/projects/badges/passing-flat.svg)](https://kpp.readthedocs.io/en/latest) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6563908.svg)](https://doi.org/10.5281/zenodo.6563908)
+tests](https://img.shields.io/azure-devops/build/KineticPreProcessor/KPP/1/main?label=C-I%20Tests)](https://dev.azure.com/KineticPreProcessor/KPP/_build) [![ReadTheDocs](https://assets.readthedocs.org/static/projects/badges/passing-flat.svg)](https://kpp.readthedocs.io/en/latest) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7308373.svg)](https://doi.org/10.5281/zenodo.7308373)
 
 # The Kinetic PreProcessor: KPP
 This is the repository for the The Kinetic PreProcessor (KPP) source code.


### PR DESCRIPTION
This enables the ["Cite this repository" button](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) on GitHub. With the current data, it generates this citation:
> Lin, H., Long, M. S., Sander, R., Sandu, A., Yantosca, R. M., Estrada, L., Shen, L., & Jacob, D. J. (2023). An adaptive auto-reduction solver for speeding up integration of chemical kinetics in atmospheric chemistry models: implementation and evaluation within the Kinetic Pre-Processor (KPP) version 3.0.0. JAMES, 15(2). https://doi.org/10.1029/2022MS003293