### PR TITLE
Remove obsolete #LUMP command (and related 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - TBD
 ### Removed
 - `TRANSPORT` and `TRANSPORTALL` input options; these were obsolete
+- `LUMP` input option; this was obsolete
 
 ## [3.0.2] - 2023-06-02
 ### Added

--- a/docs/source/tech_info/08_bnf_description_of_kpp_lang.rst
+++ b/docs/source/tech_info/08_bnf_description_of_kpp_lang.rst
@@ -20,7 +20,6 @@ Following is the BNF-like specification of the KPP language:
                             #FAMILIES family_list                                 |
                             #INITVALUES initvalues_list                           |
                             #LOOKAT species_list atom_list                        |
-                            #LUMP lump_list                                       |
                             #MONITOR species_list atom_list                       |
                             #SETFIX species_list_plus                             |
                             #SETVAR species_list_plus
@@ -88,14 +87,6 @@ Following is the BNF-like specification of the KPP language:
                             C_INIT       | C_DATA        | C_UTIL                 |
                             MATLAB_RATES | MATLAB_RCONST | MATLAB_GLOBAL          |
                             MATLAB_INIT  | MATLAB_DATA   | MATLAB_UTIL
-
- lump ::=                   lump_sum : species_name;
-
- lump_list ::=              lump                                                  |
-                            lump lump_list
-
- lump_sum ::=               species_name                                          |
-                            species_name + lump_sum
 
  rate ::=                   number                                                |
                             program_expression

--- a/docs/source/using_kpp/04_input_for_kpp.rst
+++ b/docs/source/using_kpp/04_input_for_kpp.rst
@@ -116,11 +116,10 @@ defining the species in the appropriate sections. A fixed species does
 not vary through chemical reactions.
 
 For each species the user has to declare the atom composition. This
-information is used for mass balance checking. If the species is a
-lumped species without an exact composition, its composition can be
-ignored. To do this one can declare the predefined atom
-:command:`IGNORE` as being part of the species composition. Examples for
-these sections are:
+information is used for mass balance checking.  To ignore mass balance
+checking for a given species, one can declare the predefined atom
+:command:`IGNORE` as being part of the species composition. Examples
+for these sections are:
 
 .. code-block:: console
 
@@ -321,21 +320,6 @@ Examples for these sections are:
 
    #LOOKAT NO2; CO2; O3; N;
    #MONITOR O3; N;
-
-.. _lump:
-
-#LUMP
------
-
-To reduce the stiffness of some models, various lumping of species may
-be defined in the :command:`#LUMP` section. In the example below,
-species :code:`NO` and :code:`NO2` are summed and treated as a single
-lumped variable, :code:`NO2`. Following integration, the individual
-species concentrations are recomputed from the lumped variable.
-
-.. code-block:: console
-
-   #LUMP NO2 + NO : NO2
 
 .. _setvar-and-setfix:
 

--- a/site-lisp/kpp.el
+++ b/site-lisp/kpp.el
@@ -51,7 +51,7 @@
          "\\|#HESSIAN\\|#INCLUDE\\|#INITIALIZE"
          "\\|#INITVALUES\\|#INLINE\\|#INTEGRATOR\\|#INTFILE"
          "\\|#JACOBIAN\\|#LANGUAGE\\|#LOOKATALL"
-         "\\|#LOOKAT\\|#LUMP\\|#MEX\\|#MODEL\\|#MONITOR"
+         "\\|#LOOKAT\\|#MEX\\|#MODEL\\|#MONITOR"
          "\\|#REORDER\\|#RUN\\|#SETFIX\\|#SETRAD\\|#SETVAR"
          "\\|#SPARSEDATA\\|#STOCHASTIC\\|#STOICMAT"
          "\\|#USE\\|#USES\\|#WRITE_ATM"

--- a/site-lisp/kpp_mecca.el
+++ b/site-lisp/kpp_mecca.el
@@ -52,7 +52,7 @@
          "\\|#HESSIAN\\|#INCLUDE\\|#INITIALIZE"
          "\\|#INITVALUES\\|#INLINE\\|#INTEGRATOR\\|#INTFILE"
          "\\|#JACOBIAN\\|#LANGUAGE\\|#LOOKATALL"
-         "\\|#LOOKAT\\|#LUMP\\|#MEX\\|#MODEL\\|#MONITOR"
+         "\\|#LOOKAT\\|#MEX\\|#MODEL\\|#MONITOR"
          "\\|#REORDER\\|#REPLACE\\|#RUN\\|#SETFIX\\|#SETRAD\\|#SETVAR"
          "\\|#SPARSEDATA\\|#STOCHASTIC\\|#STOICMAT"
          "\\|#USE\\|#USES\\|#WRITE_ATM"

--- a/src/scan.h
+++ b/src/scan.h
@@ -87,8 +87,6 @@ void AssignInitialValue( char *spname , char *spval );
 void StoreEquationRate( char *rate, char *label );
 void CheckEquation(); 
 void ProcessTerm( int side, char *sign, char *coef, char *spname  );
-void AddLumpSpecies( char *spname );
-void CheckLump( char *spname );
 void AddLookAt( char *spname );
 void AddMonitor( char *spname );
 

--- a/src/scan.l
+++ b/src/scan.l
@@ -252,17 +252,6 @@ STOICH  {LIT}[a-zA-Z_0-9]*[*]
 <RATE_STATE>;           { BEGIN EQN_STATE;
                           RETURN( yytext[0] );
                         } 
-<LMP_STATE>{IDSPC}      { strcpy( yylval.str, yytext );
-                          RETURN( LMPSPC );
-                        }
-<LMP_STATE>[+]          { RETURN( LMPPLUS );
-                        } 
-<LMP_STATE>[:]          { RETURN( LMPCOLON );
-                        } 
-<LMP_STATE>;            { RETURN( yytext[0] );
-                        } 
-<LMP_STATE>[^;#]        { ScanError("Invalid character '%c' in species definition", yytext[0] );
-                        }
 <LKT_STATE>{IDSPC}      { strcpy( yylval.str, yytext );
                           RETURN( LKTID );
                         }
@@ -335,7 +324,6 @@ STOICH  {LIT}[a-zA-Z_0-9]*[*]
                          { "INITVALUES",    INI_STATE, INITVALUES   },
                          { "EQUATIONS",     EQN_STATE, EQUATIONS    },
                          { "FAMILIES",      FAM_STATE, FAMILIES     },
-                         { "LUMP",          LMP_STATE, LUMP         },
                          { "LOOKAT",        LKT_STATE, LOOKAT       },
                          { "LOOKATALL",     INITIAL,   LOOKATALL    },
                          { "INITIALIZE",    PRM_STATE, INITIALIZE   },

--- a/src/scan.y
+++ b/src/scan.y
@@ -79,16 +79,16 @@
 
 %token JACOBIAN DOUBLE FUNCTION DEFVAR DEFRAD DEFFIX SETVAR SETRAD SETFIX 
 %token HESSIAN STOICMAT STOCHASTIC DECLARE
-%token INITVALUES EQUATIONS FAMILIES LUMP INIEQUAL EQNEQUAL EQNCOLON 
-%token LMPCOLON LMPPLUS SPCPLUS SPCEQUAL FAMCOLON ATOMDECL CHECK CHECKALL REORDER
+%token INITVALUES EQUATIONS FAMILIES INIEQUAL EQNEQUAL EQNCOLON
+%token SPCPLUS SPCEQUAL FAMCOLON ATOMDECL CHECK CHECKALL REORDER
 %token MEX DUMMYINDEX EQNTAGS
 %token LOOKAT LOOKATALL MONITOR USES SPARSEDATA
 %token WRITE_ATM WRITE_SPC WRITE_MAT WRITE_OPT INITIALIZE XGRID YGRID ZGRID
 %token USE LANGUAGE INTFILE DRIVER RUN INLINE ENDINLINE
 %token      PARAMETER SPCSPC INISPC INIVALUE EQNSPC EQNSIGN EQNCOEF
 %type <str> PARAMETER SPCSPC INISPC INIVALUE EQNSPC EQNSIGN EQNCOEF
-%token      RATE LMPSPC SPCNR ATOMID LKTID MNIID INLCTX INCODE SSPID 
-%type <str> RATE LMPSPC SPCNR ATOMID LKTID MNIID INLCTX INCODE SSPID
+%token      RATE SPCNR ATOMID LKTID MNIID INLCTX INCODE SSPID
+%type <str> RATE SPCNR ATOMID LKTID MNIID INLCTX INCODE SSPID
 %token      EQNLESS EQNTAG EQNGREATER
 %type <str> EQNLESS EQNTAG EQNGREATER
 %token      TPTID USEID
@@ -158,8 +158,6 @@ section	        : JACOBIAN PARAMETER
                 | EQUATIONS equations
                   {}
                 | FAMILIES families
-                  {}
-                | LUMP lumps  
                   {}
                 | LOOKAT lookatlist  
                   {}
@@ -392,19 +390,6 @@ term            : EQNCOEF EQNSPC
                     strcpy( crt_coef, "1" ); 
                   }
                 ;
-lumps           : lumps lump semicolon
-                | lump semicolon 
-                | error semicolon
-                  { ParserErrorMessage(); }
-                ;
-lump            : LMPSPC LMPPLUS lump
-                  { AddLumpSpecies( $1 );
-                  }
-                | LMPSPC LMPCOLON LMPSPC
-                  {
-                    AddLumpSpecies( $1 );
-                    CheckLump( $3 );  
-                  }
 inlinecode      : inlinecode INCODE
 		  {
 		    InlineBuf = AppendString( InlineBuf, $2, &InlineLen, MAX_INLINE );
@@ -468,7 +453,7 @@ void ParserErrorMessage()
       break; 
     case EQNCOLON: 
       ParserError("Missing rate after '%s'", crtToken );
-      break; 
+      break;
     case EQNSIGN: 
       ParserError("Missing coeficient after '%s'", crtToken );
       break; 
@@ -477,16 +462,6 @@ void ParserErrorMessage()
       break; 
     case RATE: 
       ParserError("Missing ';' after '%s'", crtToken );
-      break; 
-
-    case LMPSPC: 
-      ParserError("Missing '+' or ':' or ';' after '%s'", crtToken );
-      break; 
-    case LMPPLUS: 
-      ParserError("Missing species after '%s'", crtToken );
-      break; 
-    case LMPCOLON: 
-      ParserError("Missing species after '%s'", crtToken );
       break; 
     case INLINE:
       ParserError("Missing inline option after '%s'", crtToken );

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -800,28 +800,6 @@ char eqNr[40];
   }
 }
            
-void AddLumpSpecies( char *spname )
-{
-int code;  
-  
-  code = FindSpecies( spname );
-  if ( code < 0 ) {
-    ScanError("Undefined species %s.", spname );
-    return;
-  }
-}
-
-void CheckLump( char *spname )
-{
-int code;  
-  
-  code = FindSpecies( spname );
-  if ( code < 0 ) {
-    ScanError("Undefined species %s.", spname );
-    return;
-  }
-}
-
 void AddLookAt( char *spname )
 {
 int code;  


### PR DESCRIPTION
### Overview

This PR removes the obsolete `#TRANSPORT` and `#TRANSPORTALL` commands from KPP.  These are very old commands and probably have not worked in a very long time.

### Modifications

`docs/source/tech_info/08_bnf_description_of_kpp_lang.rst`
- Remove `#LUMP`, `lump`, `lump_sum`, `lump_list` from BNF syntax list

`docs/source/using_kpp/04_input_for_kpp.rst`
- Remove `#LUMP` section
- Remove reference to lumped species in `#DEFVAR` and `#DEFFIX` section

`site-lisp/kpp.el`
`site-lisp/kpp_mecca.el`
- Remove `#LUMP` from the font-lock-mode list

`src/scan.h`
- Remove function prototypes for` AddLumpSpecies`, `CheckLump`

`src/scan.l`
- Remove references to `LMP_STATE` and `LUMP`

`src/scan.y`
- Remove references to `LUMP`, `LMPCOLON`, `LMPPLUS`, `LMPSPC`, `lumps`, `lump`

`src/scanner.c`
- Remove C-language routines `AddLumpSpecies`, `CheckLump`

`CHANGELOG.md`
- Updated accordingly