### PR TITLE
Matlab bug fix: only add Aout to Fun and Fun_Split for F90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Python package versions for ReadTheDocs in `docs/requirements.txt`
 - Now request Python 3.12 for ReadTheDocs builds in `.readthedocs.yaml`
 
+### Fixed
+- Now only add tha extra `Aout` argument to `Fun` and `Fun_Split` for F90 (see issues #56, #96)
+
 <!-- Version numbers must be synchronized in CHANGELOG.md, -->
 <!-- src/gdata.h, and docs/source/conf.py-->
 ## [3.1.0] - 2023-12-20

--- a/src/gen.c
+++ b/src/gen.c
@@ -652,12 +652,20 @@ int F_VAR, FSPLIT_VAR;
   // Note: When changing the FunctionBegin declarations below,
   // the number of arguments minus one must be changed in DefFnc here
   // as well. (hplin, 7/6/22)
-  F_VAR = DefFnc( "Fun", 5,
-                  "time derivatives of variables - Aggregate form");
-
-  FSPLIT_VAR = DefFnc( "Fun_SPLIT", 7,
-                       "time derivatives of variables - Split form");
-
+  // 
+  // For F90, add an extra argument to Fun and Fun_Split to return
+  // the Aout array. (hplin, bmy, 30 Apr 2024)
+  if (useLang == F90_LANG) {
+    F_VAR = DefFnc("Fun", 5,
+		   "time derivatives of variables - Aggregate form");
+    FSPLIT_VAR = DefFnc("Fun_SPLIT", 7,
+			"time derivatives of variables - Split form");
+  } else {
+    F_VAR = DefFnc("Fun", 4,
+                   "time derivatives of variables - Aggregate form");
+    FSPLIT_VAR = DefFnc("Fun_SPLIT", 6,
+                        "time derivatives of variables - Split form");
+  }
 
   // We have added the capability to return equation rates and the
   // time derivative of variable species from Fun via optional arguments
@@ -665,11 +673,21 @@ int F_VAR, FSPLIT_VAR;
   //   -- Bob Yantosca (03 May 2022)
   //
   // Vdotout functionality can be accomplished using Vdot (hplin, 7/6/22)
+  //
+  // F90 needs Fun to have an extra argument for Aout (hplin, bmy, 30 Apr 2024)
   if( z_useAggregate ) {
-    FunctionBegin( F_VAR, V, F, RCT, Vdot, Aout );
+    if (useLang == F90_LANG) {
+      FunctionBegin( F_VAR, V, F, RCT, Vdot, Aout );\
+    } else {
+      FunctionBegin( F_VAR, V, F, RCT, Vdot );
+    }
   }
   else {
-    FunctionBegin( FSPLIT_VAR, V, F, RCT, Vdot, P_VAR, D_VAR, Aout );
+    if (useLang == F90_LANG) {
+      FunctionBegin( FSPLIT_VAR, V, F, RCT, Vdot, P_VAR, D_VAR, Aout );
+    } else {
+      FunctionBegin( FSPLIT_VAR, V, F, RCT, Vdot, P_VAR, D_VAR );
+    }
   }
 
   if ( (useLang==MATLAB_LANG)&&(!z_useAggregate) )


### PR DESCRIPTION
This PR implemenmts the fix proposed by @jimmielin in issue #56.  Namely, we now declare `FUN` and `FUN_SPLIT` with an extra argument (`Aout`) only for the F90 target language.  This should fix the problem described by @jnavarla in #96.