### PR TITLE
Fixes to allow using the full MCM

### DIFF
--- a/src/code_f90.c
+++ b/src/code_f90.c
@@ -120,7 +120,7 @@ int first;
 int crtident;
 
 /* if MAX_NO_OF_LINES is too small, KPP will split lines incorrectly */
-int number_of_lines = 1, MAX_NO_OF_LINES = 250;
+int number_of_lines = 1, MAX_NO_OF_LINES = 2000;
 
 /*  Operator Mapping: 0xaa = '*' | 0xab = '+' | 0xac = ','
                       0xad = '-' | 0xae ='.' | 0xaf = '/' */

--- a/src/gdata.h
+++ b/src/gdata.h
@@ -57,11 +57,14 @@
 //       problems on MacOS then consider reducing MAX_EQN and MAX_SPECIES
 //       to smaller values than are listed below.
 //         -- Bob Yantosca (03 May 2022)
+//   (3) The large value of MAX_EQN = 18000 is necessary to run the
+//       complete MCM mechanism in KPP.
+//         -- Rolf Sander (2024-01-03)
 #ifdef MACOS
 #define MAX_EQN        2000     // Max number of equations (MacOS only)
 #define MAX_SPECIES    1000     // Max number of species   (MacOS only)
 #else
-#define MAX_EQN       11000     // Max number of equations
+#define MAX_EQN       18000     // Max number of equations
 #define MAX_SPECIES    6000     // Max number of species
 #endif
 #define MAX_SPNAME       30     // Max char length of species name

--- a/util/Makefile_f90
+++ b/util/Makefile_f90
@@ -36,7 +36,7 @@ FC_HPUX    = f90
 FOPT_HPUX  = -O -u +Oall +check=on
 
 FC_GFORTRAN     = gfortran
-FOPT_GFORTRAN   = -cpp -O -g
+FOPT_GFORTRAN   = -cpp -O -g -frecursive
 
 # define FULL_ALGEBRA for non-sparse integration
 FC   = $(FC_$(COMPILER))


### PR DESCRIPTION
This PR seeks to merge a couple of outstanding commits in the `feature/mcm` branch into dev.  Namely to increase the size of arrays needed to use the full MCM and also to add the `-recursive` flag to gfortran.