### PR TITLE
Use Y instead of C in Update_RCONST

### DIFF
--- a/.ci-pipelines/ci-common-defs.sh
+++ b/.ci-pipelines/ci-common-defs.sh
@@ -46,6 +46,18 @@ function get_ci_test_path() {
     return
 }
 
+# Prints a headeer with the compiler versions
+function print_compiler_versions() {
+    echo \
+"###########################################################################"
+    echo "         KPP CONTINUOUS INTEGRATION TESTS, USING THESE COMPILERS:"
+    echo ""
+    gcc --version
+    gfortran --version
+    echo \
+"###########################################################################"
+}
+
 # Run a C-I test
 function run_ci_test() {
 

--- a/.ci-pipelines/ci-testing-script.sh
+++ b/.ci-pipelines/ci-testing-script.sh
@@ -10,6 +10,9 @@
 # Current directory
 cwd=$(pwd -P)
 
+# Print a header with the compiler versions
+print_compiler_versions
+
 # Run C-I tests with various mechanism + integrator combinations
 for this_test in ${GENERAL_TESTS}; do
     run_ci_test "${this_test}" "${cwd}" ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - TBD
 ### Changed
 - Use `Y` instead of `C` in `Update_RCONST` to account for updated variable species concentrations
+- C-I tests now print the compiler version that are used
 
 ### Fixed
 - Add `char* rootFileName` to functions and function prototypes for `Use_C`, `Use_F`, `Use_F90`, `Use_MATLAB`, and `Generate`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
+### Changed
+- Use `Y` instead of `C` in `Update_RCONST` to account for updated variable species concentrations
+
 ### Fixed
 - Add `char* rootFileName` to functions and function prototypes for `Use_C`, `Use_F`, `Use_F90`, `Use_MATLAB`, and `Generate`
 

--- a/docs/source/citations/09_acknowledgments.rst
+++ b/docs/source/citations/09_acknowledgments.rst
@@ -41,4 +41,7 @@ Stuart Lacy wrote an export function for the `Master Chemical Mechanism
 used out-of-the-box for the small model in the :file:`examples/mcm`
 directory.
 
+Simon Rosanka improved the :code:`Update_RCONST` subroutine by providing
+time-dependent concentration values via an optional parameter.
+
 Parts of this user manual are based on :cite:t:`Damian-Iordache_1996`.

--- a/docs/source/using_kpp/04_input_for_kpp.rst
+++ b/docs/source/using_kpp/04_input_for_kpp.rst
@@ -224,18 +224,6 @@ These reactions must be merged by adding the rate coefficients:
 
    N2O5 + H2O = 2 HNO3 : k_gas + k_aerosol;
 
-If the reaction rate coefficient depends on the concentration of a specific
-species, :code:`Y` should be referenced instead of :code:`C` in the reaction
-rate coefficient declaration. This ensures that the species concentration at
-the specific integration time is used when the reaction rate coefficient is
-updated within the integrator. In the following example, the reaction rate
-coefficient depends on the concentration of the hydrogen ion, whose
-concentration at that specific integration time is given by :code:`Y(ind_Hp)`:
-
-.. code-block:: console
-
-   HSO3m + HSO5m + Hp = 2 HSO4m + Hp : k_aqueous( Y(ind_Hp) );
-
 .. _families:
 
 #FAMILIES
@@ -1232,6 +1220,18 @@ ICNTRL
    :code:`Update_SUN` and :code:`Update_PHOTO`, but not to
    :code:`Update_RCONST`.
 
+   Calling :code:`Update_RCONST` may be necessary when reaction rate
+   coefficients depend on the concentration of a specific species, e.
+   g.:
+
+   .. code-block:: console
+                   
+      HSO3m + HSO5m + Hp = 2 HSO4m + Hp : k_aqueous( C(ind_Hp) );
+   
+   This ensures that the concentration :code:`C(ind_Hp)` at the specific
+   integration time is used when the reaction rate coefficient is
+   updated within the integrator.
+   
 .. option:: ICNTRL(16)
 
    Treatment of negative concentrations:

--- a/docs/source/using_kpp/04_input_for_kpp.rst
+++ b/docs/source/using_kpp/04_input_for_kpp.rst
@@ -224,6 +224,18 @@ These reactions must be merged by adding the rate coefficients:
 
    N2O5 + H2O = 2 HNO3 : k_gas + k_aerosol;
 
+If the reaction rate coefficient depends on the concentration of a specific
+species, :code:`Y` should be referenced instead of :code:`C` in the reaction
+rate coefficient declaration. This ensures that the species concentration at
+the specific integration time is used when the reaction rate coefficient is
+updated within the integrator. In the following example, the reaction rate
+coefficient depends on the concentration of the hydrogen ion, whose
+concentration at that specific integration time is given by :code:`Y(ind_Hp)`:
+
+.. code-block:: console
+
+   HSO3m + HSO5m + Hp = 2 HSO4m + Hp : k_aqueous( Y(ind_Hp) );
+
 .. _families:
 
 #FAMILIES

--- a/int/rosenbrock.f90
+++ b/int/rosenbrock.f90
@@ -1326,7 +1326,7 @@ SUBROUTINE FunTemplate( T, Y, Ydot, P_VAR, D_VAR )
    Told = TIME
    TIME = T
    IF ( Do_Update_SUN    ) CALL Update_SUN()
-   IF ( Do_Update_RCONST ) CALL Update_RCONST()
+   IF ( Do_Update_RCONST ) CALL Update_RCONST(Y)
    CALL KPP_FUN_OR_FUN_SPLIT
    TIME = Told
 
@@ -1364,7 +1364,7 @@ SUBROUTINE JacTemplate( T, Y, Jcb )
     Told = TIME
     TIME = T
     IF ( Do_Update_SUN    ) CALL Update_SUN()
-    IF ( Do_Update_RCONST ) CALL Update_RCONST()
+    IF ( Do_Update_RCONST ) CALL Update_RCONST(Y)
 #ifdef FULL_ALGEBRA
     CALL Jac_SP(Y, FIX, RCONST, JV)
     DO j=1,NVAR

--- a/int/rosenbrock_adj.f90
+++ b/int/rosenbrock_adj.f90
@@ -2523,7 +2523,7 @@ SUBROUTINE FunTemplate( T, Y, Ydot )
    Told = TIME
    TIME = T
    IF ( Do_Update_SUN    ) CALL Update_SUN()
-   IF ( Do_Update_RCONST ) CALL Update_RCONST()
+   IF ( Do_Update_RCONST ) CALL Update_RCONST(Y)
    CALL Fun( Y, FIX, RCONST, Ydot )
    TIME = Told
 
@@ -2554,7 +2554,7 @@ SUBROUTINE JacTemplate( T, Y, Jcb )
     Told = TIME
     TIME = T
     IF ( Do_Update_SUN    ) CALL Update_SUN()
-    IF ( Do_Update_RCONST ) CALL Update_RCONST()
+    IF ( Do_Update_RCONST ) CALL Update_RCONST(Y)
 #ifdef FULL_ALGEBRA
     CALL Jac_SP(Y, FIX, RCONST, JV)
     DO j=1,NVAR
@@ -2591,7 +2591,7 @@ SUBROUTINE HessTemplate( T, Y, Hes )
     Told = TIME
     TIME = T
     IF ( Do_Update_SUN    ) CALL Update_SUN()
-    IF ( Do_Update_RCONST ) CALL Update_RCONST()
+    IF ( Do_Update_RCONST ) CALL Update_RCONST(Y)
     CALL Hessian( Y, FIX, RCONST, Hes )
     TIME = Told
 

--- a/int/rosenbrock_autoreduce.f90
+++ b/int/rosenbrock_autoreduce.f90
@@ -2471,7 +2471,7 @@ SUBROUTINE FunTemplate( T, Y, Ydot, P_VAR, D_VAR )
    Told = TIME
    TIME = T
    IF ( Do_Update_SUN    ) CALL Update_SUN()
-   IF ( Do_Update_RCONST ) CALL Update_RCONST()
+   IF ( Do_Update_RCONST ) CALL Update_RCONST(Y)
    CALL KPP_FUN_OR_FUN_SPLIT
    TIME = Told
 
@@ -2568,7 +2568,7 @@ SUBROUTINE JacTemplate( T, Y, Jcb )
     Told = TIME
     TIME = T
     IF ( Do_Update_SUN    ) CALL Update_SUN()
-    IF ( Do_Update_RCONST ) CALL Update_RCONST()
+    IF ( Do_Update_RCONST ) CALL Update_RCONST(Y)
 #ifdef FULL_ALGEBRA
     CALL Jac_SP(Y, FIX, RCONST, JV)
     DO j=1,NVAR

--- a/int/rosenbrock_tlm.f90
+++ b/int/rosenbrock_tlm.f90
@@ -1348,7 +1348,7 @@ SUBROUTINE FunTemplate( T, Y, Ydot )
    Told = TIME
    TIME = T
    IF ( Do_Update_SUN    ) CALL Update_SUN()
-   IF ( Do_Update_RCONST ) CALL Update_RCONST()
+   IF ( Do_Update_RCONST ) CALL Update_RCONST(Y)
    CALL Fun( Y, FIX, RCONST, Ydot )
    TIME = Told
 
@@ -1373,7 +1373,7 @@ SUBROUTINE JacTemplate( T, Y, Jcb )
     Told = TIME
     TIME = T
     IF ( Do_Update_SUN    ) CALL Update_SUN()
-    IF ( Do_Update_RCONST ) CALL Update_RCONST()
+    IF ( Do_Update_RCONST ) CALL Update_RCONST(Y)
     CALL Jac_SP( Y, FIX, RCONST, Jcb )
     TIME = Told
 
@@ -1398,7 +1398,7 @@ SUBROUTINE HessTemplate( T, Y, Hes )
     Told = TIME
     TIME = T
     IF ( Do_Update_SUN    ) CALL Update_SUN()
-    IF ( Do_Update_RCONST ) CALL Update_RCONST()
+    IF ( Do_Update_RCONST ) CALL Update_RCONST(Y)
     CALL Hessian( Y, FIX, RCONST, Hes )
     TIME = Told
 

--- a/src/gen.c
+++ b/src/gen.c
@@ -2167,14 +2167,31 @@ void GenerateUpdateRconst()
 {
 int i;
 int UPDATE_RCONST;
+int YIN,Y;
 
   UseFile( rateFile );
 
-  UPDATE_RCONST = DefFnc( "Update_RCONST", 0, "function to update rate constants");
+  YIN = DefvElmO( "YIN", real, -NVAR, "Optional input concentrations of variable species" );
+  UPDATE_RCONST = DefFnc( "Update_RCONST", 1, "function to update rate constants");
 
-  FunctionBegin( UPDATE_RCONST );
+  FunctionBegin( UPDATE_RCONST, YIN );
+
+  Y = DefvElm( "Y", real, -NSPEC, "Concentrations of species (local)" );
+  Declare(Y);
+  NewLines(1);
+
   F77_Inline("      INCLUDE '%s_Global.h'", rootFileName);
   MATLAB_Inline("global SUN TEMP RCONST");
+
+  switch( useLang ){
+        case F90_LANG:
+                WriteComment("Ensure local Y array is filled with variable and constant concentrations");
+                bprintf("  Y(1:NSPEC) = C(1:NSPEC)\n");
+                NewLines(1);
+                WriteComment("Update local Y array if variable concentrations are provided");
+                bprintf("  if (present(YIN)) Y(1:NVAR) = YIN(1:NVAR)\n");
+                break;
+  }
 
   if ( useLang==F77_LANG )
       IncludeCode( "%s/util/UserRateLaws_FcnHeader", Home );

--- a/src/gen.c
+++ b/src/gen.c
@@ -2171,14 +2171,20 @@ int YIN,Y;
 
   UseFile( rateFile );
 
-  YIN = DefvElmO( "YIN", real, -NVAR, "Optional input concentrations of variable species" );
-  UPDATE_RCONST = DefFnc( "Update_RCONST", 1, "function to update rate constants");
+  if (useLang==F90_LANG) {
+    // F90: Declare function with optional YIN argument and local Y variable.
+    YIN = DefvElmO( "YIN", real, -NVAR, "Optional input concentrations of variable species" );
+    UPDATE_RCONST = DefFnc( "Update_RCONST", 1, "function to update rate constants");
 
-  FunctionBegin( UPDATE_RCONST, YIN );
-
-  Y = DefvElm( "Y", real, -NSPEC, "Concentrations of species (local)" );
-  Declare(Y);
-  NewLines(1);
+    FunctionBegin( UPDATE_RCONST, YIN );
+    Y = DefvElm( "Y", real, -NSPEC, "Concentrations of species (local)" );
+    Declare(Y);
+    NewLines(1);
+  } else {
+    // For other languages, declare function w/o any arguments
+    UPDATE_RCONST = DefFnc( "Update_RCONST", 0, "function to update rate constants");
+    FunctionBegin( UPDATE_RCONST );
+ }
 
   F77_Inline("      INCLUDE '%s_Global.h'", rootFileName);
   MATLAB_Inline("global SUN TEMP RCONST");


### PR DESCRIPTION
This pull request includes the necessary changes such that in Update_RCONST variable concentrations for rate constants that depend on species concentrations are used. To ensure backwards compatibility, YIN is an optional input. If YIN is not passed to Update_RCONST, concentrations from the global C array are used instead.

Closes #93