### PR TITLE
Add inlined code in the #INLINE F90_RCONST_USE block to the Update_Photo routine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added new inline key `F90_RCONST_USE` in `src/gdata.h` and `src/scanner.c`
 - Added documentation about `F90_RCONST_USE` for ReadTheDocs
+- Added `F90_RCONST_USE` inlined code to `Update_RConst`and `Update_Photo` routines
 
 ### Changed
 - Updated `Update_RCONST` to use `Y` instead of `C` to account for updated variable species concentrations
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Added `char* rootFileName` to functions and function prototypes for `Use_C`, `Use_F`, `Use_F90`, `Use_MATLAB`, and `Generate`
 - Updated `docs/requirements.txt` to use `jinja2==3.1.4` (fixes a security issue)
+- Moved `USE constants_mcm` from `F90_RCONST` to `F90_RCONST_USE` in `examples/mcm/mcm_isoprene.eqn`
 
 ## [3.1.1] - 2024-04-30
 ### Changed

--- a/docs/source/using_kpp/04_input_for_kpp.rst
+++ b/docs/source/using_kpp/04_input_for_kpp.rst
@@ -939,10 +939,10 @@ computed, such as:
    #ENDINLINE
 
 The inlined code will be placed directly into the subroutines
-:code:`UPDATE_RCONST` in the :ref:`Rates` file.  :code:`USE`
-statements will be placed before Fortran variable definitions and
-executable statements, as is required by the Fortran-90 language
-standard. 
+:code:`UPDATE_RCONST` and :code:`UPDATE_PHOTO` in the :ref:`Rates`
+file.  :code:`USE` statements will be placed before Fortran variable
+definitions and executable statements, as is required by the
+Fortran-90 language standard.  
 
 .. _f90-util:
 

--- a/docs/source/using_kpp/04_input_for_kpp.rst
+++ b/docs/source/using_kpp/04_input_for_kpp.rst
@@ -934,7 +934,7 @@ computed, such as:
 
 .. code-block:: fortran
 
-   #INLINE F90_RCONST
+   #INLINE F90_RCONST_USE
      USE MyRateFunctionModule
    #ENDINLINE
 

--- a/examples/mcm/mcm_isoprene.eqn
+++ b/examples/mcm/mcm_isoprene.eqn
@@ -662,8 +662,12 @@ C536OOH = IGNORE ;
 C537O = IGNORE ;
 C537OOH = IGNORE ;
 
-#INLINE F90_RCONST 
+#INLINE F90_RCONST_USE
+  ! Use statment to be inlined into Update_RCONST
   USE constants_mcm
+#ENDINLINE
+
+#INLINE F90_RCONST
   ! Peroxy radicals
   ! WARNING: The following species do not have SMILES strings in the database. 
   !           If any of these are peroxy radicals the RO2 sum will be wrong! 

--- a/src/gen.c
+++ b/src/gen.c
@@ -2300,6 +2300,21 @@ int UPDATE_PHOTO;
   UPDATE_PHOTO = DefFnc( "Update_PHOTO", 0, "function to update photolytical rate constants");
 
   FunctionBegin( UPDATE_PHOTO );
+
+  if (useLang==F90_LANG) {
+    //
+    // SPECIAL HANDLING FOR F90:
+    // -------------------------
+    // Inline USE statements right after the subroutine declaration
+    WriteComment("Begin inlined code from F90_RCONST_USE");
+    NewLines(1);
+    bprintf( InlineCode[ F90_RCONST_USE ].code );
+    FlushBuf();
+    NewLines(1);
+    WriteComment("End inlined code from F90_RCONST_USE");
+    NewLines(1);
+  }
+
   F77_Inline("      INCLUDE '%s_Global.h'", rootFileName);
   /*  mz_rs_20220212+ */
   /* global is already used in the rates module, don't use it twice */


### PR DESCRIPTION
This PR fixes a bug that I found when trying to run the C-I tests for the MCM mechanism.  The fix does the following:

1. Added code to the `GenerateUpdatePhoto` routine in `src/gen.c` to so that any F90 use statements specified in `#INLINE F90_RCONST_USE` will be inlined at the top of the `Update_PHOTO` routine.   This will prevent compilation errors.

2. Moved the `USE constants_mcm` statement (in `examples/mcm/mcm_isoprene.eqn`) from `#INLINE F90_RCONST` to `#INLINE F90_RCONST_USE`, so that it will be placed at the proper place at the top of the subroutine before any declaration or executable statements.

3. Edited the ReadTheDocs documentation for `F90_RCONST_USE` to state that any use statements specified here will be placed into both `Update_RCONST` and `Update_PHOTO`.
