### PR TITLE
Fixed MacOS-specific handling for x86_64 or arm64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `char* rootFileName` to functions and function prototypes for `Use_C`, `Use_F`, `Use_F90`, `Use_MATLAB`, and `Generate`
 - Updated `docs/requirements.txt` to use `jinja2==3.1.4` (fixes a security issue)
 - Moved `USE constants_mcm` from `F90_RCONST` to `F90_RCONST_USE` in `examples/mcm/mcm_isoprene.eqn`
+- Fixed MacOS-specific handling for x86_64 or arm64 in `src/Makefile.defs`
 
 ## [3.1.1] - 2024-04-30
 ### Changed

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@
 #
 #  Copyright (C) 1995-1996 Valeriu Damian and Adrian Sandu
 #  Copyright (C) 1997-2005 Adrian Sandu
-#      with contributions from: Mirela Damian, Rolf Sander 
+#      with contributions from: Mirela Damian, Rolf Sander
 #
 #  KPP is free software; you can redistribute it and/or modify it under the
 #  terms of the GNU General Public License as published by the Free Software
@@ -56,8 +56,8 @@ all: $(OBJS)
 	@mv kpp $(PROG)
 
 .PHONY: clean
-clean:  
-	@rm -f *~ *.o 
+clean:
+	@rm -f *~ *.o
 
 .PHONY: distclean
 distclean: clean
@@ -71,6 +71,7 @@ maintainer-clean: distclean
 .PHONY: list
 list:
 	@echo "SYSTEM       = $(SYSTEM)"
+	@echo "SYSTEM_M     = $(SYSTEM_M)"
 	@echo "HOST         = $(HOST)"
 	@echo "CC           = $(CC)"
 	@echo "CC_FLAGS     = $(CC_FLAGS)"
@@ -83,7 +84,7 @@ list:
 	$(CC) $(CC_FLAGS) -I$(INCLUDE_DIR) -c $*.c
 
 lex.yy.c: scan.l scan.h gdata.h
-	$(FLEX) -olex.yy.c scan.l 
+	$(FLEX) -olex.yy.c scan.l
 
 y.tab.c: scan.y scan.h
 	$(BISON) -d -o y.tab.c scan.y
@@ -101,6 +102,6 @@ debug.o:              gdata.h scan.h
 gen.o:         code.h gdata.h scan.h
 kpp.o:                gdata.h scan.h
 lex.yy.o:             gdata.h scan.h y.tab.h
-scanner.o:            gdata.h scan.h 
+scanner.o:            gdata.h scan.h
 scanutil.o:           gdata.h scan.h
 y.tab.o:                      scan.h y.tab.h

--- a/src/Makefile.defs
+++ b/src/Makefile.defs
@@ -73,18 +73,18 @@ FLEX         := flex
 FLEX_LIB_DIR := /usr/lib
 BISON        := bison
 INCLUDE_DIR  := /usr/include
-SYSTEM       := $(shell uname)        # returns e.g. "Linux"
-SYSTEM_M     := $(shell uname -m)     # returns e.g. "x86_64"
-HOST         := $(shell hostname)     # returns name of machine
+SYSTEM       := $(shell uname)       # e.g. "Linux", "Darwin"
+SYSTEM_M     := $(shell uname -m)    # e.g. "x86_64", "arm64"
+HOST         := $(shell hostname)    # name of machine
 
 ############################################################
 ### Keep looking for the flex library until found        ###
 ### Otherwise use the path specified in KPP_FLEX_LIB_DIR ###
 ###                                                      ###
 ### NOTE for MacOS X: IF you have installed flex with    ###
-### HomeBrew, then flex will be installed to a path such ### 
+### HomeBrew, then flex will be installed to a path such ###
 ### as /usr/local/Cellar/flex/X.Y.Z/lib, where X.Y.Z is  ###
-### the version number.  --  Bob Yantosca (01 Nov 2021)  ###   
+### the version number.  --  Bob Yantosca (01 Nov 2021)  ###
 ############################################################
 
 # Try /usr/lib64
@@ -128,8 +128,18 @@ endif
 ############################################################
 
 # Settings for MacOS
-ifeq ($(SYSTEM),Darwin)
+ifeq ($(strip $(SYSTEM)),Darwin)
   CC_FLAGS += -DMACOS -O
+  ifeq ($(strip $(SYSTEM_M)),x86_64)
+    # Build for Intel x86_64 chipsets
+    CC_FLAGS += -arch x86_64
+  else
+    ifeq ($(strip $(SYSTEM_M)),arm64)
+      # Build for Apple Silicon chipsets
+      CC_FLAGS += -arch arm64
+    else
+      $(warning Unknown architecture: $(strip $(SYSTEM_M)))
+    endif
+  endif
 endif
-
 #############################################################


### PR DESCRIPTION
This is the companion PR to #126, in which we do the following:

- Use the GNU Make `$(strip )` command to trim trailing whitespace before testing the values of variables `SYSTEM` and `SYSTEM_M` for string equality.  Trailing whitespace was causing the string equality tests to fail.
- Add `-arch x86_64` to `CC_FLAGS` if compiling on MacOS with Linux x86_64 chipsets
- Add `-arch arm64` to `CC_FLAGS` if compiling on MacOS with Apple Silicon chipsets

As you can see the Mac-specific options are now added:

```console
gcc -g -Wall -Wno-unused-function -DMACOS -O -arch x86_64 -I/usr/include -c code.c
gcc -g -Wall -Wno-unused-function -DMACOS -O -arch x86_64 -I/usr/include -c code_c.c
gcc -g -Wall -Wno-unused-function -DMACOS -O -arch x86_64 -I/usr/include -c code_f77.c
gcc -g -Wall -Wno-unused-function -DMACOS -O -arch x86_64 -I/usr/include -c code_f90.c
code_f90.c:319:5: warning: variable 'nlines' set but not used [-Wunused-but-set-variable]
  319 | int nlines;
      |     ^
1 warning generated.
gcc -g -Wall -Wno-unused-function -DMACOS -O -arch x86_64 -I/usr/include -c code_matlab.c
code_matlab.c:262:5: warning: variable 'nlines' set but not used [-Wunused-but-set-variable]
  262 | int nlines;
      |     ^
1 warning generated.
gcc -g -Wall -Wno-unused-function -DMACOS -O -arch x86_64 -I/usr/include -c debug.c
gcc -g -Wall -Wno-unused-function -DMACOS -O -arch x86_64 -I/usr/include -c gen.c
gcc -g -Wall -Wno-unused-function -DMACOS -O -arch x86_64 -I/usr/include -c kpp.c
gcc -g -Wall -Wno-unused-function -DMACOS -O -arch x86_64 -I/usr/include -c lex.yy.c
gcc -g -Wall -Wno-unused-function -DMACOS -O -arch x86_64 -I/usr/include -c scanner.c
gcc -g -Wall -Wno-unused-function -DMACOS -O -arch x86_64 -I/usr/include -c scanutil.c
gcc -g -Wall -Wno-unused-function -DMACOS -O -arch x86_64 -I/usr/include -c y.tab.c
gcc -g -Wall -Wno-unused-function -DMACOS -O -arch x86_64 code.o code_c.o code_f77.o code_f90.o code_matlab.o debug.o gen.o kpp.o lex.yy.o scanner.o scanutil.o y.tab.o -L/usr/local/Cellar/flex/2.6.4_2/lib -lfl -o kpp
```

Tagging @HartwigHarder