### PR TITLE
Fix compiler warnings by removing "rootFileName" from Use_F, Use_F90, Use_C, Use_Matlab, Generate functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - TBD
 ### Changed
-- Removed `rootFileName` from calls to `USE_F`, `USE_F90`, `USE_C`, `USE_MATLAB` to match the function prototypes in `code.h`
+- Removed `rootFileName` from calls to `USE_F`, `USE_F90`, `USE_C`, `USE_MATLAB`, and `Generate` to match corresponding function prototypes
 
 ## [3.1.1] - 2024-04-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Changed
+- Removed `rootFileName` from calls to `USE_F`, `USE_F90`, `USE_C`, `USE_MATLAB` to match the function prototypes in `code.h`
+
 ## [3.1.1] - 2024-04-30
 ### Changed
 - Updated Python package versions for ReadTheDocs in `docs/requirements.txt`

--- a/src/gen.c
+++ b/src/gen.c
@@ -3490,15 +3490,14 @@ int n;
   outBuf = (char*)malloc( n );
   outBuffer = outBuf;
 
+  // rootFileName is now in gdata.h, so we don't
+  // have to pass it to the USE_* functions.
+  //  -- Bob Yantosca (13 Feb 2025)
   switch( useLang ) {
-    case F77_LANG: Use_F( rootFileName );
-                 break;
-    case F90_LANG: Use_F90( rootFileName );
-                 break;
-    case C_LANG: Use_C( rootFileName );
-                 break;
-    case MATLAB_LANG: Use_MATLAB( rootFileName );
-                 break;
+    case F77_LANG:    Use_F();      break;
+    case F90_LANG:    Use_F90();    break;
+    case C_LANG:      Use_C();      break;
+    case MATLAB_LANG: Use_MATLAB(); break;
     default: printf("\n Language no '%d' unknown\n",useLang );
   }
   printf("\nKPP is initializing the code generation.");

--- a/src/kpp.c
+++ b/src/kpp.c
@@ -594,7 +594,8 @@ char *p;
   if( initNr == -1 ) initNr = VarNr;
 
   printf("\nKPP is starting the code generation.");
-  Generate( rootFileName );
+  //Generate( rootFileName );
+  Generate();
   
   printf("\nKPP is starting the code post-processing.");
   Postprocess( rootFileName );

--- a/src/kpp.c
+++ b/src/kpp.c
@@ -594,7 +594,6 @@ char *p;
   if( initNr == -1 ) initNr = VarNr;
 
   printf("\nKPP is starting the code generation.");
-  //Generate( rootFileName );
   Generate();
   
   printf("\nKPP is starting the code post-processing.");


### PR DESCRIPTION
This PR fixes compiler warnings such as these:
```console
gcc -g -Wall -Wno-unused-function -I/usr/include -c debug.c
gcc -g -Wall -Wno-unused-function -I/usr/include -c gen.c
gen.c:3494:25: warning: passing arguments to 'Use_F' without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
 3494 |     case F77_LANG: Use_F( rootFileName );
      |                         ^
gen.c:3496:27: warning: passing arguments to 'Use_F90' without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
 3496 |     case F90_LANG: Use_F90( rootFileName );
      |                           ^
gen.c:3498:23: warning: passing arguments to 'Use_C' without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
 3498 |     case C_LANG: Use_C( rootFileName );
      |                       ^
gen.c:3500:33: warning: passing arguments to 'Use_MATLAB' without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
 3500 |     case MATLAB_LANG: Use_MATLAB( rootFileName );
      |                                 ^
4 warnings generated.
```
and
```console
gcc -g -Wall -Wno-unused-function -I/usr/include -c kpp.c
kpp.c:597:11: warning: passing arguments to 'Generate' without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
  597 |   Generate( rootFileName );
      |           ^
1 warning generated.
```

The fix is to remove the `rootFileName` argument from the `USE_F`, `USE_F90`, `USE_C`, `USE_MATLAB`, and `Generate` functions.  This makes them consistent with the corresponding function prototypes (which do not have an argument) in `code.h` and `gdata.h`.

The `rootFileName` variable is declared as `extern char*` in `gdata.h` so it does not need to be passed as an argument to these routines.

NOTE: These warnings are generated with recent GNU compilers (GCC 13 or 14).