### PR TITLE
Return Texit from the Forward Euler (feuler) integrator and add corresponding C-I test

### DIFF
--- a/.ci-pipelines/ci-common-defs.sh
+++ b/.ci-pipelines/ci-common-defs.sh
@@ -28,6 +28,7 @@ F90_sd
 F90_sdadj
 F90_seulex
 F90_small_strato
+F90_feuler
 "
 # Testing if #MINVERSION works
 MINVERSION_TEST="X_minver"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Added
+- Added C-I test `F90_feuler`, using the Forward Euler integrator
+- Added carbon gases mechanism (`models/carbon.*`)
+
+### Fixed
+- Updated `int/feuler.f90` to return the `Texit` value as `RSTATUS(1)` (this was not being done)
+
 ## [3.2.0] - 2025-02-27
 ### Added
 - Added new inline key `F90_RCONST_USE` in `src/gdata.h` and `src/scanner.c`

--- a/ci-tests/F90_feuler/F90_feuler.kpp
+++ b/ci-tests/F90_feuler/F90_feuler.kpp
@@ -1,0 +1,9 @@
+#MINVERSION   3.2.0
+#INTEGRATOR   feuler
+#LANGUAGE     Fortran90
+#UPPERCASEF90 on
+#MODEL        carbon
+#DRIVER       general
+#HESSIAN      off
+#MEX          off
+#STOICMAT     off

--- a/docs/source/using_kpp/05_output_from_kpp.rst
+++ b/docs/source/using_kpp/05_output_from_kpp.rst
@@ -1229,7 +1229,7 @@ RSTATUS
    +----------------------------+---+---+---+---+
    | exponential                |   |   |   |   |
    +----------------------------+---+---+---+---+
-   | feuler                     |   |   |   |   |
+   | feuler                     | Y |   |   |   |
    +----------------------------+---+---+---+---+
    | gillespie                  |   |   |   |   |
    +----------------------------+---+---+---+---+
@@ -1271,7 +1271,7 @@ RSTATUS
 
 .. option:: RSTATUS(2)
 
-  :code:`Hexit`: the last accepted step before exit.
+   :code:`Hexit`: the last accepted step before exit.
 
 .. option:: RSTATUS(3)
 

--- a/int/feuler.f90
+++ b/int/feuler.f90
@@ -110,6 +110,9 @@ CONTAINS
    VAR => NULL()
    FIX => NULL()
 
+   !~~~> Return the ending timestep as RSTATUS(1)
+   RSTATUS(1) = TOUT
+
    !~~~> Return error status (NOTE: ISTATUS_U does nothing)
    IF ( PRESENT( IERR_U    ) ) IERR_U    = IERR
    IF ( PRESENT( RSTATUS_U ) ) RSTATUS_U = RSTATUS

--- a/models/carbon.def
+++ b/models/carbon.def
@@ -1,0 +1,40 @@
+//
+// Example based on the GEOS-Chem carbon gases mechanism
+//
+
+// Species definitions
+#INCLUDE carbon.spc
+
+// Equation definitions
+#INCLUDE carbon.eqn
+
+// Output all species to carbon.dat
+#LOOKATALL
+
+// Print selected species to screen
+#MONITOR CH4; CO; PCOfromCH4; PCOfromNMVOC; LCH4byOH; LCObyOH;
+
+// Initial conditions
+#INITVALUES
+   CFACTOR      = 1.0e+00;
+   CH4          = 4.6703420e+13;
+   CO           = 3.4487402e+12;
+   PCOfromCH4   = 2.5302681e-01;
+   PCOfromNMVOC = 2.5302681e-01;
+   LCH4byOH     = 2.5302681e-01;
+   LCH4byCl     = 2.5302681e-01;
+   LCObyOH      = 2.5302681e-01;
+   FixedOH      = 1.0121073e+05;
+   FixedCl      = 2.5302681e-01;
+   DummyCH4     = 4.5544823e+13;
+   DummyNMVOC   = 2.5302681e-01;
+
+// F90 code to be inlined into ROOT_Global
+#INLINE F90_INIT
+   TSTART       = 0.0d0
+   TEND         = TSTART + (3.0d0 * 24.0d0 * 3600.0d0)
+   DT           = 3600.0d0
+   TEMP         = 270.0d0
+#ENDINLINE
+
+// NOTE: The Forward Euler integrator is only implemented in Fortran90!

--- a/models/carbon.eqn
+++ b/models/carbon.eqn
@@ -1,0 +1,9 @@
+//
+// Example based on the GEOS-Chem carbon gases mechanism
+//
+#EQUATIONS
+<R1> CH4      + FixedOH = LCH4byOH                : 2.45d-12*EXP(-1775.0d0/TEMP);
+<R2> CH4      + FixedCl = LCH4byCl                : 9.60d-12*EXP(-1360.0d0/TEMP);
+<R3> DummyCH4           = CO       + PCOfromCH4   : 4.2566446d-15;
+<R4> CO       + FixedOH = LCObyOH                 : 7.3679649d-14;
+<R5> DummyNMVOC         = CO       + PCOfromNMVOC : 3.8199012d+04;

--- a/models/carbon.spc
+++ b/models/carbon.spc
@@ -1,0 +1,20 @@
+//
+// Example based on the GEOS-Chem carbon gases mechanism
+//
+
+#include atoms.kpp      { Periodic table information              }
+
+#DEFVAR
+CH4          = IGNORE;  { Active methane species                  }
+CO           = IGNORE;  { Active carbon monoxide species          }
+PCOfromCH4   = IGNORE;  { Tracks P(CO) from CH4   for diagnostics }
+PCOfromNMVOC = IGNORE;  { Tracks P(CO) from NMVOC for diagnostics }
+LCH4byOH     = IGNORE;  { Dummy spc to track loss of CH4 by OH    }
+LCH4byCl     = IGNORE;  { Dummy spc to track loss of CH4 by Cl    }
+LCObyOH      = IGNORE;  { Dummy spc to track loss of CO  by OH    }
+
+#DEFFIX
+FixedOH      = IGNORE;  { Externally-supplied OH concentration    }
+FixedCl      = IGNORE;  { Externally-supplied Cl concentration    }
+DummyCH4     = IGNORE;  { Dummy placeholder for CH4   reactant    }
+DummyNMVOC   = IGNORE;  { Dummy placeholder for NMVOC reactant    }


### PR DESCRIPTION
This is the companion PR to #135.  In this PR we have now done the following:

1. Modified the `int/feuler.f90` ("Forward Euler") integrator to return `Texit` (the time corresponding to the computed Y value) from to the calling program via `RSTATUS(1)`.  This was a bug that was causing box-model simulations using the `general` driver to fail, as the driver was not getting the updated time after each integration call. 

2. Added a new model named `carbon` based on the GEOS-Chem carbon gases mechanism.  Files describing the model are located at `models/carbon.def`, `models/carbon.eqn`, `models/carbon.spc`.

3. Added a new C-I test for the Forward Euler integrator using the carbon model.

4. Updated ReadTheDocs documentation to denote that the Forward Euler (feuler) integrator now uses `RSTATUS(1)`.

Closes #135

Tagging @RolfSander @jimmielin @msl3v 