### PR TITLE
fix: `KPP_ROOT_Stoichiom.f90` is not compiled if `#STOICMAT ON` and `#HESSIAN OFF`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - TBD
+### Fixed
+- Fixed a bug in Makefile template that caused `KPP_ROOT_Stoichiom.f90` not compiled if `#STOICMAT ON` and `#HESSIAN OFF`
+
 ## [3.3.0] - 2025-07-17
 ### Added
 - New integrator: `rosenbrock_h211b_qssa.f90`

--- a/util/Makefile_f90
+++ b/util/Makefile_f90
@@ -145,9 +145,9 @@ ifeq ($(HAS_STM_SP),1)
   STMOBJ   += KPP_ROOT_StoichiomSP.o
   STMSPOBJ += KPP_ROOT_StoichiomSP.o
 endif
-ifeq ($(HAS_HES),1)
-  HESSRC   += KPP_ROOT_Stoichiom.f90
-  HESOBJ   += KPP_ROOT_Stoichiom.o
+ifeq ($(HAS_STM),1)
+  STMSRC   += KPP_ROOT_Stoichiom.f90
+  STMOBJ   += KPP_ROOT_Stoichiom.o
 endif
 
 UTLSRC = KPP_ROOT_Rates.f90 KPP_ROOT_Util.f90 KPP_ROOT_Monitor.f90

--- a/util/Makefile_upper_F90
+++ b/util/Makefile_upper_F90
@@ -145,9 +145,9 @@ ifeq ($(HAS_STM_SP),1)
   STMOBJ   += KPP_ROOT_StoichiomSP.o
   STMSPOBJ += KPP_ROOT_StoichiomSP.o
 endif
-ifeq ($(HAS_HES),1)
-  HESSRC   += KPP_ROOT_Stoichiom.F90
-  HESOBJ   += KPP_ROOT_Stoichiom.o
+ifeq ($(HAS_STM),1)
+  STMSRC   += KPP_ROOT_Stoichiom.F90
+  STMOBJ   += KPP_ROOT_Stoichiom.o
 endif
 
 UTLSRC = KPP_ROOT_Rates.F90 KPP_ROOT_Util.F90 KPP_ROOT_Monitor.F90


### PR DESCRIPTION

util/Makefile_f90
- add `KPP_ROOT_Stoichiom.f90` to compile target if exist

util/Makefile_upper_F90
- same as above, but for `#UPPERCASEF90 ON`

CHANGELOG.md
- Updated accordingly