### PR TITLE
Create variables to track non-passive species, so that they can be excluded from the Rosenbrock error norm (in int/rosenbrock*.f90 integrators only)

### DIFF
--- a/.ci-pipelines/ci-common-defs.sh
+++ b/.ci-pipelines/ci-common-defs.sh
@@ -24,6 +24,7 @@ F90_rosadj
 F90_ros_autoreduce
 F90_rosenbrock
 F90_ros_h211b
+F90_ros_passivespc
 F90_ros_split
 F90_rostlm
 F90_ros_upcase

--- a/.github/workflows/run-ci-tests.yml
+++ b/.github/workflows/run-ci-tests.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install libraries
         run: |
           sudo apt update -y
+          sudo apt install -y software-properties-common
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt update -y
           sudo apt install -y flex bison libfl-dev
           sudo apt install -y gcc-${{ matrix.gcc-version }} g++-${{ matrix.gcc-version }} gfortran-${{ matrix.gcc-version }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ matrix.gcc-version }} 100 \

--- a/.github/workflows/run-ci-tests.yml
+++ b/.github/workflows/run-ci-tests.yml
@@ -20,7 +20,7 @@ jobs:
       KPP_FLEX_LIB_DIR: /usr/lib/x86_64-linux-gnu
     strategy:
       matrix:
-        gcc-version: [9, 10, 11, 12, 13]
+        gcc-version: [9, 10, 11, 12, 13, 14, 15]
 
 
     name: Run C-I tests with GCC ${{ matrix.gcc-version }}

--- a/.github/workflows/run-ci-tests.yml
+++ b/.github/workflows/run-ci-tests.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Install libraries
         run: |
+          sudo grep -rl 'packages.microsoft.com' /etc/apt/sources.list.d/ | xargs -r sudo rm -f
           sudo apt update -y
           sudo apt install -y software-properties-common
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/.github/workflows/run-ci-tests.yml
+++ b/.github/workflows/run-ci-tests.yml
@@ -20,7 +20,7 @@ jobs:
       KPP_FLEX_LIB_DIR: /usr/lib/x86_64-linux-gnu
     strategy:
       matrix:
-        gcc-version: [9, 10, 11, 12, 13, 14, 15]
+        gcc-version: [9, 10, 11, 12, 13, 14, 15, 16]
 
 
     name: Run C-I tests with GCC ${{ matrix.gcc-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased] - TBD
+### Added
+- Added function `F90_FunctionBeginNoArgDecl` in `src/code_f90.c` with corresponding function prototypes in `src/code.c` and `src/code.h`
+- Added macro `DefElmO` in `src/code.h`, which writes a scalar F90 variable with the `OPTIONAL` attribute
+
 ### Changed
 - Updated `Makefile.defs` and `util/Makefile*` to look for the value of `CC` or `FC` from the shell before explicitly setting it
 - Updated documentation about forcing MacOSX to prefer GNU compilers over Clang

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added macro `DefElmO` in `src/code.h`, which writes a scalar F90 variable with the `OPTIONAL` attribute
 - Added code to `src/gen.c` to add `NonPassiveSpc_Count` and `NonPassiveSpc_Indices` to `ROOT_Global` (only for F90)
 - Added code to `src/gen.c` to filter out passive species if the `PassiveSpc_ATOL_Threshold` optioal argument is passed to `ROOT_Initialize` (F90-only)
+- Added GCC 14 and GCC 15 to the list of compilers used to run C-I tests in GitHub Actions
 
 ### Changed
 - Updated `Makefile.defs` and `util/Makefile*` to look for the value of `CC` or `FC` from the shell before explicitly setting it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated documentation about forcing MacOSX to prefer GNU compilers over Clang
 - Updated `Makefile.defs` with robust cross-architecture code
 - Updated the C-I test function `print_compiler_versions` to display the proper compiler info
+- Initialized `Hacc` and `ErrOld` variables to `ZERO` in `int/runge_kutta.c`, to avoid compiler warnings
 
 ### Fixed
 - Fixed several emacs font-lock issues in `site-lisp/kpp.el`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added GCC 14, 15, and 16 to the list of compilers used to run C-I tests in GitHub Actions
 - Added `F90_ros_passivespc` C-I test to validate filtering out of passive species
 - Added `drv/general_passivespc.f90` driver program, which passes optional `PassiveSpc_ATOL_Threshold` argument to `ROOT_Initialize`
+- Added documentation about excluding passive species to ReadTheDocs
 
 ### Changed
 - Updated `Makefile.defs` and `util/Makefile*` to look for the value of `CC` or `FC` from the shell before explicitly setting it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed several emacs font-lock issues in `site-lisp/kpp.el`
 - Fixed `src/gen.c` to avoid generating an uninitialized variable compiler warning
 
+### Removed
+- Removed references to unneccessary `azure-cli` and `microsoft-prod` packages in `.github/workflows/run-ci-tests.yml`
+
 ## [3.4.0] - 2026-04-29
 ### Added
 - Added `Rodas3_1` integration method (with updated coefficents by @msl3v) to `rosenbrock_autoreduce.f90`, `rosenbrock.{c,f90,m}`, `rosenbrock_adj.{c,f90}`, `rosenbrock_tlm.f90`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added macro `DefElmO` in `src/code.h`, which writes a scalar F90 variable with the `OPTIONAL` attribute
 - Added code to `src/gen.c` to add `NonPassiveSpc_Count` and `NonPassiveSpc_Indices` to `ROOT_Global` (only for F90)
 - Added code to `src/gen.c` to filter out passive species if the `PassiveSpc_ATOL_Threshold` optioal argument is passed to `ROOT_Initialize` (F90-only)
-- Added GCC 14 and GCC 15 to the list of compilers used to run C-I tests in GitHub Actions
+- Added GCC 14, 15, and 16 to the list of compilers used to run C-I tests in GitHub Actions
 - Added `F90_ros_passivespc` C-I test to validate filtering out of passive species
 - Added `drv/general_passivespc.f90` driver program, which passes optional `PassiveSpc_ATOL_Threshold` argument to `ROOT_Initialize`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added code to `src/gen.c` to add `NonPassiveSpc_Count` and `NonPassiveSpc_Indices` to `ROOT_Global` (only for F90)
 - Added code to `src/gen.c` to filter out passive species if the `PassiveSpc_ATOL_Threshold` optioal argument is passed to `ROOT_Initialize` (F90-only)
 - Added GCC 14 and GCC 15 to the list of compilers used to run C-I tests in GitHub Actions
+- Added `F90_ros_passivespc` C-I test to validate filtering out of passive species
+- Added `drv/general_passivespc.f90` driver program, which passes optional `PassiveSpc_ATOL_Threshold` argument to `ROOT_Initialize`
 
 ### Changed
 - Updated `Makefile.defs` and `util/Makefile*` to look for the value of `CC` or `FC` from the shell before explicitly setting it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added function `F90_FunctionBeginNoArgDecl` in `src/code_f90.c` with corresponding function prototypes in `src/code.c` and `src/code.h`
 - Added macro `DefElmO` in `src/code.h`, which writes a scalar F90 variable with the `OPTIONAL` attribute
+- Added code to `src/gen.c` to add `NonPassiveSpc_Count` and `NonPassiveSpc_Indices` to `ROOT_Global` (only for F90)
+- Added code to `src/gen.c` to filter out passive species if the `PassiveSpc_ATOL_Threshold` optioal argument is passed to `ROOT_Initialize` (F90-only)
 
 ### Changed
 - Updated `Makefile.defs` and `util/Makefile*` to look for the value of `CC` or `FC` from the shell before explicitly setting it
@@ -23,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `Makefile.defs` with robust cross-architecture code
 - Updated the C-I test function `print_compiler_versions` to display the proper compiler info
 - Initialized `Hacc` and `ErrOld` variables to `ZERO` in `int/runge_kutta.c`, to avoid compiler warnings
+- Updated all `int/rosenbrock*.f90` integrators to use `NonPassiveSpc_Count` and `NonPassiveSpc_Indices` to exclude passive species from the error norm calculation
 
 ### Fixed
 - Fixed several emacs font-lock issues in `site-lisp/kpp.el`

--- a/ci-tests/F90_ros_passivespc/F90_ros_passivespc.kpp
+++ b/ci-tests/F90_ros_passivespc/F90_ros_passivespc.kpp
@@ -1,0 +1,66 @@
+#INCLUDE    atoms.kpp              { Periodic table definitions              }
+#INTEGRATOR rosenbrock             { Use rosenbrock integrator               }
+#LANGUAGE   Fortran90              { Use F90 language                        }
+#DRIVER     general_passivespc     { Use the general driver program          }
+
+
+#DEFVAR                            { VARIABLE SPECIES                        }
+O     = O;                         { Oxygen atomic ground state              }
+O1D   = O;                         { Oxygen atomic excited state             }
+O3    = O + O + O;                 { Ozone                                   }
+NO    = N + O;                     { Nitric oxide                            }
+NO2   = N + O + O;                 { Nitrogen dioxide                        }
+PASV1 = IGNORE;                    { Passive species 1                       }
+PASV2 = IGNORE;                    { Passive species 2                       }
+PASV3 = IGNORE;                    { Passive species 3                       }
+
+
+#DEFFIX                            { FIXED SPECIES                           }
+M     = O + O + N + N;             { Atmospheric generic molecule            }
+O2    = O + O;                     { Molecular oxygen                        }
+
+
+#EQUATIONS                         { SMALL STRATOSPHERIC MECHANISM           }
+<R1>  O2   + hv = 2O               : (2.643E-10) * SUN*SUN*SUN;
+<R2>  O    + O2 = O3               : (8.018E-17);
+<R3>  O3   + hv = O   + O2         : (6.120E-04) * SUN;
+<R4>  O    + O3 = 2O2              : (1.576E-15);
+<R5>  O3   + hv = O1D + O2         : (1.070E-03) * SUN*SUN;
+<R6>  O1D  + M  = O   + M          : (7.110E-11);
+<R7>  O1D  + O3 = 2O2      + PASV1 : (1.200E-10);
+<R8>  NO   + O3 = NO2 + O2 + PASV2 : (6.062E-15);
+<R9>  NO2  + O  = NO  + O2         : (1.069E-11);
+<R10> NO2  + hv = NO  + O  + PASV3 : (1.289E-02) * SUN;
+
+
+                                   { OUTPUT OPTIONS                          }
+#LOOKATALL                         { Output all species to small_strato.dat  }
+#MONITOR O3;N;O2;O;NO;O1D;NO2;     { Print selected species to screen        }
+
+
+#CHECK O; N;                       { Check Mass Balance of oxygen & nitrogen }
+
+
+#INITVALUES                        { Set initial values of species           }
+  CFACTOR = 1.0e0     ;            { and set units conversion factor to 1    }
+  O1D     = 9.906E+01 ;
+  O       = 6.624E+08 ;
+  O3      = 5.326E+11 ;
+  O2      = 1.697E+16 ;
+  NO      = 8.725E+08 ;
+  NO2     = 2.240E+08 ;
+  M       = 8.120E+16 ;
+  PASV1   = 0.0e0     ;
+  PASV2   = 0.0e0     ;
+  PASV3   = 0.0e0     ;
+
+                                   { F90 code to be inlined into ROOT_Global }
+#INLINE F90_INIT
+  ATOL(ind_PASV1) = 1.0d25
+  ATOL(ind_PASV2) = 1.0d25
+  ATOL(ind_PASV3) = 1.0d25
+  TSTART          = (12 * 3600)
+  TEND            = TSTART + (3* 24 * 3600)
+  DT              = 0.25 * 3600
+  TEMP            = 270
+#ENDINLINE

--- a/docs/source/getting_started/00_revision_history.rst
+++ b/docs/source/getting_started/00_revision_history.rst
@@ -10,6 +10,21 @@ of the changes, read `CHANGELOG.md
 
 .. _unreleased:
 
+==========
+Unreleased
+==========
+
+- Updated KPP code to exclude passive species from the Rosenbrock
+  error norm computation when the optional
+  :code:`PassiveSpc_ATOL_Threshold` argument is passed to the
+  :code:`Initialize` routine
+- Added `F90_ros_passivespc` C-I test and `drv/general_passivespc.f90`
+  driver program
+- Added GCC compiler versions 14, 15, and 16 to the "Run C-I tests"
+  GitHub Action
+- Fixed several build issues for MacOSX with ARM chipsets
+- Fixed emacs font-lock issues in :file:`site_lisp/kpp.el`
+
 .. _kpp340:
 
 =========

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,32 +1,52 @@
+.. |br| raw:: html
+
+   <br />
+
 #############################
 The Kinetic PreProcessor: KPP
 #############################
 
-.. raw:: html
+| **An Environment for the Simuation of Chemical Kinetic Systems**
 
-   <h3>An Environment for the<br/>Simuation of Chemical Kinetic Systems</h3>
-   <p><strong>Adrian Sandu<sup>1</sup>, Rolf Sander<sup>2</sup>,
-   Michael S. Long<sup>3</sup>, Haipeng Lin<sup>4</sup>,<br />
-   Robert M. Yantosca<sup>4</sup>, Lucas Estrada<sup>4</sup>, Lu
-   Shen<sup>5</sup>, and Daniel J. Jacob<sup>4</sup></strong></p>
-   <p><em>
-     <sup>1</sup> Virginia Polytechnic Institute and State University, Blacksburg, VA, USA<br/>
-     <sup>2</sup> Max-Planck Institute for Chemistry, Mainz, Germany<br/>
-     <sup>3</sup> Renaissance Fiber, LLC, North Carolina, USA<br/>
-     <sup>4</sup> Harvard John A. Paulson School of Engineering and
-     Applied Sciences, Cambridge, MA, USA<br />
-     <sup>5</sup> School of Physics, Peking University, Bejing, China</em>
-   </p>
-   </hr>
-   <p>
-   <a href="https://github.com/KineticPreProcessor/KPP/releases/"><img src="https://img.shields.io/github/v/release/KineticPreProcessor/KPP?include_prereleases&label=Latest%20Pre-Release"></a>
-   <a href="https://github.com/KineticPreProcessor/KPP/releases/"><img src="https://img.shields.io/github/v/release/KineticPreProcessor/KPP?label=Latest%20Stable%20Release"></a>
-   <a href="https://github.com/KineticPreProcessor/KPP/releases/"><img src="https://img.shields.io/github/release-date/KineticPreProcessor/KPP"></a>
-   <a href="https://github.com/KineticPreProcessor/KPP/blob/main/LICENSE.txt"><img src="https://img.shields.io/badge/License-GPLv3-blue.svg"></a>
-   <a href="https://doi.org/10.5281/zenodo.6828025"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.6828025.svg"></a>
-   <a href="https://kpp.readthedocs.io/en/latest/"><img src="https://img.shields.io/readthedocs/kpp?label=ReadTheDocs"></a>
-   <a href="https://dev.azure.com/KineticPreProcessor/KPP/_build?definitionId=1"><img src="https://dev.azure.com/KineticPreProcessor/KPP/_apis/build/status/KineticPreProcessor.KPP?branchName=dev"></a>
-   </p>
+| **Adrian Sandu**\ :sup:`1`\ **, Rolf Sander**\ :sup:`2`\ **, Michael S. Long**\ :sup:`3`\ **, Haipeng Lin**\ :sup:`4`\ **,**
+| **Robert M. Yantosca**\ :sup:`4`\ **, Lucas Estrada**\ :sup:`4`\ **, Lu Shen**\ :sup:`5`\ **, and Daniel J. Jacob**\ :sup:`4`
+
+| :sup:`1` *Virginia Polytechnic Institute and State University, Blacksburg, VA, USA*
+| :sup:`2` *Max-Planck Institute for Chemistry, Mainz, Germany*
+| :sup:`3` *Renaissance Fiber, LLC, North Carolina, USA*
+| :sup:`4` *Harvard John A. Paulson School of Engineering and Applied Sciences, Cambridge, MA, USA*
+| :sup:`5` *School of Physics, Peking University, Beijing, China*
+
+----
+
+.. |latest-stable-release| image:: https://img.shields.io/github/v/release/KineticPreProcessor/KPP?label=Latest%20Stable%20Release
+   :target: https://github.com/KineticPreProcessor/KPP/releases/
+   :alt: Latest Stable Release
+
+.. |release-date| image:: https://img.shields.io/github/release-date/KineticPreProcessor/KPP
+   :target: https://github.com/KineticPreProcessor/KPP/releases/
+   :alt: Release Date
+
+.. |license| image:: https://img.shields.io/badge/License-GPLv3-blue.svg
+   :target: https://github.com/KineticPreProcessor/KPP/blob/main/LICENSE.txt
+   :alt: License: GPLv3
+
+.. |doi| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.6828025.svg
+   :target: https://doi.org/10.5281/zenodo.6828025
+   :alt: DOI
+
+.. |readthedocs| image:: https://readthedocs.org/projects/kpp/badge/?version=stable
+   :target: https://kpp.readthedocs.io/en/latest/
+   :alt: ReadTheDocs
+
+.. |ci-tests| image:: https://github.com/KineticPreProcessor/KPP/actions/workflows/run-ci-tests.yml/badge.svg
+   :target: https://github.com/KineticPreProcessor/KPP/actions/workflows/run-ci-tests.yml
+   :alt: C-I tests
+
+|latest-stable-release| |release-date| |license| |br|
+|doi| |readthedocs| |ci-tests|
+
+----
 
 This site provides instructions for :program:`KPP`, the Kinetic PreProcessor.
 

--- a/docs/source/tech_info/06_info_for_kpp_developers.rst
+++ b/docs/source/tech_info/06_info_for_kpp_developers.rst
@@ -25,48 +25,49 @@ Contains the KPP source code files:
 
 .. _table-kpp-dirs:
 
-.. table:: KPP source code files
+.. list-table:: KPP source code files
    :align: center
+   :widths: 30 70
+   :header-rows: 1
 
-   +-----------------------+-------------------------------------+
-   | File                  | Description                         |
-   +=======================+=====================================+
-   | :file:`kpp.c`         | Main program                        |
-   +-----------------------+-------------------------------------+
-   | :file:`code.c`        | generic code generation functions   |
-   +-----------------------+-------------------------------------+
-   | :file:`code.h`        | Header file                         |
-   +-----------------------+-------------------------------------+
-   | :file:`code_c.c`      | Generation of C code                |
-   +-----------------------+-------------------------------------+
-   | :file:`code_f90.c`    | Generation of F90 code              |
-   +-----------------------+-------------------------------------+
-   | :file:`code_matlab.c` | Generation of Matlab code           |
-   +-----------------------+-------------------------------------+
-   | :file:`debug.c`       | Debugging output                    |
-   +-----------------------+-------------------------------------+
-   | :file:`gdata.h`       | Header file                         |
-   +-----------------------+-------------------------------------+
-   | :file:`gdef.h`        | Header file                         |
-   +-----------------------+-------------------------------------+
-   | :file:`gen.c`         | Generic code generation functions   |
-   +-----------------------+-------------------------------------+
-   | :file:`lex.yy.c`      | Flex generated file                 |
-   +-----------------------+-------------------------------------+
-   | :file:`scan.h`        | Input for Flex and Bison            |
-   +-----------------------+-------------------------------------+
-   | :file:`scan.l`        | Input for Flex                      |
-   +-----------------------+-------------------------------------+
-   | :file:`scan.y`        | Input for Bison                     |
-   +-----------------------+-------------------------------------+
-   | :file:`scanner.c`     | Evaluate parsed input               |
-   +-----------------------+-------------------------------------+
-   | :file:`scanutil.c`    | Evaluate parsed input               |
-   +-----------------------+-------------------------------------+
-   | :file:`y.tab.c`       | Bison generated file                |
-   +-----------------------+-------------------------------------+
-   | :file:`y.tab.h`       | Bison generated header file         |
-   +-----------------------+-------------------------------------+
+   * - File
+     - Description
+   * - :file:`kpp.c`
+     - Main program
+   * - :file:`code.c`
+     - generic code generation functions
+   * - :file:`code.h`
+     - Header file
+   * - :file:`code_c.c`
+     - Generation of C code
+   * - :file:`code_f90.c`
+     - Generation of F90 code
+   * - :file:`code_matlab.c`
+     - Generation of Matlab code
+   * - :file:`debug.c`
+     - Debugging output
+   * - :file:`gdata.h`
+     - Header file
+   * - :file:`gdef.h`
+     - Header file
+   * - :file:`gen.c`
+     - Generic code generation functions
+   * - :file:`lex.yy.c`
+     - Flex generated file
+   * - :file:`scan.h`
+     - Input for Flex and Bison
+   * - :file:`scan.l`
+     - Input for Flex
+   * - :file:`scan.y`
+     - Input for Bison
+   * - :file:`scanner.c`
+     - Evaluate parsed input
+   * - :file:`scanutil.c`
+     - Evaluate parsed input
+   * - :file:`y.tab.c`
+     - Bison generated file
+   * - :file:`y.tab.h`
+     - Bison generated header file
 
 bin/
 ----
@@ -371,131 +372,167 @@ List of continuous integration tests
      - Language
      - Model
      - Integrator
+     - What it tests
    * - :code:`C_rk`
      - C
      - small_strato
      - runge_kutta
+     - :ref:`Runge-Kutta integrator <rk-methods-3stage>`
    * - :code:`C_rosadj`
      - C
      - small_strato
      - rosenbrock_adj
+     - :ref:`Rosenbrock discrete adjoint <rosenbrock-adjoint>`
    * - :code:`C_sd`
      - C
      - small_strato
      - sdirk
+     - :ref:`SDIRK integrator <rk-methods-sdirk>`
    * - :code:`C_sdadj`
      - C
      - small_strato
      - sdirk_adj
+     - :ref:`SDIRK discrete adjoint <rk-methods-sdirk>`
    * - :code:`C_small_strato`
      - C
      - small_strato
      - rosenbrock
+     - :ref:`Rosenbrock integrator <rosenbrock-methods>`
    * - :code:`F90_feuler`
      - Fortran90
      - carbon
      - feuler
+     - :ref:`Forward Euler integrator <other-methods-feuler>`
    * - :code:`F90_graph`
      - Fortran90
      - small_strato
      - rosenbrock
+     - :ref:`#GRAPH command <graph-cmd>`
    * - :code:`F90_lsode`
      - Fortran90
      - small_strato
      - lsode
+     - :ref:`LSODE integrator <back-diff-lsode>`
    * - :code:`F90_mcm`
      - Fortran90
      - mcm
      - rosenbrock
+     - Master Chemical Mechanism
    * - :code:`F90_mcm_h211b`
      - Fortran90
      - mcm
      - rosenbrock_h211b_qssa
+     - :ref:`Rosenbrock int. w/ H211b time stepping <rosenbrock-h211b-qssa>`
    * - :code:`F90_radau`
      - Fortran90
      - saprc99
      - radau5
+     - :ref:`RADAU5 integrator <rk-methods-radau5>`
    * - :code:`F90_rk`
      - Fortran90
      - small_strato
      - runge_kutta
+     - :ref:`Runge-Kutta integrator <rk-methods-3stage>`
    * - :code:`F90_rkadj`
      - Fortran90
      - small_strato
      - runge_kutta_adj
+     - :ref:`Runge-Kutta discrete adjoint <rk-methods-adj>`
    * - :code:`F90_rktlm`
      - Fortran90
      - small_strato
      - runge_kutta_tlm
+     - :ref:`Runge-Kutta tangent linear model <rk-methods-tlm>`
    * - :code:`F90_ros`
      - Fortran90
      - small_strato
      - rosenbrock
+     - :ref:`Rosenbrock integrator <rosenbrock-methods>`
    * - :code:`F90_rosadj`
      - Fortran90
      - small_strato
      - rosenbrock_adj
+     - :ref:`Rosenbrock discrete adjoint <rosenbrock-adjoint>`
    * - :code:`F90_ros_autoreduce`
      - Fortran90
      - saprc99
      - rosenbrock_autoreduce
+     - :ref:`Rosenbrock integrator w/ auto-reduction <rosenbrock-autoreduce>`
    * - :code:`F90_rosenbrock`
      - Fortran90
      - saprc99
      - rosenbrock
+     - :ref:`Rosenbrock integrator <rosenbrock-methods>`
    * - :code:`F90_ros_h211b`
      - Fortran90
      - saprc99
      - rosenbrock_h211b_qssa
+     - :ref:`Rosenbrock int. w/ H211b time stepping <rosenbrock-h211b-qssa>`
+   * - :code:`F90_ros_passivespc`
+     - Fortran90
+     - small_strato
+     - rosenbrock
+     - Excluding passive species
    * - :code:`F90_ros_split`
      - Fortran90
      - small_strato
      - rosenbrock
+     - :ref:`#FUNCTION SPLIT <function-cmd>`
    * - :code:`F90_rostlm`
      - Fortran90
      - small_strato
      - rosenbrock_tlm
+     - :ref:`Rosenbrock tangent linear model <rosenbrock-tlm>`
    * - :code:`F90_ros_upcase`
      - Fortran90
      - saprc99
      - rosenbrock
+     - :ref:`#UPPERCASEF90 ON <uppercasef90-cmd>`
    * - :code:`F90_saprc_2006`
      - Fortran90
      - saprcnov
      - rosenbrock
+     - :ref:`Rosenbrock integrator <rosenbrock-methods>`
    * - :code:`F90_sd4`
      - Fortran90
      - small_strato
      - sdirk4
+     - :ref:`Rosenbrock integrator <rosenbrock-methods>`
    * - :code:`F90_sd`
      - Fortran90
      - small_strato
      - sdirk
+     - :ref:`SDIRK integrator <rk-methods-sdirk>`
    * - :code:`F90_sdadj`
      - Fortran90
      - small_strato
      - sdirk_adj
+     - :ref:`SDIRK discrete adjoint <rk-methods-sdirk>`
    * - :code:`F90_sdtlm`
      - Fortran90
      - small_strato
      - sdirk_tlm
+     - :ref:`SDIRK tangent linear model <rk-methods-sdirk>`
    * - :code:`F90_seulex`
      - Fortran90
      - saprcnov
      - seulex
+     - :ref:`SEULEX integrator <rk-methods-seulex>`
    * - :code:`F90_small_strato`
      - Fortran90
      - small_strato
      - rosenbrock
+     - :ref:`Rosenbrock integrator <rosenbrock-methods>`
    * - :code:`X_minver`
      - Fortran90
      - small_strato
      - runge_kutta
+     - :ref:`#MINVERSION command <minversion-cmd>`
 
 Notes about C-I tests:
 
-#. :file:`F90_ros_split` also uses :command:`#FUNCTION SPLIT`.
-#. :file:`F90_ros_upcase` also uses :command:`#UPPERCASEF90 ON`.
+#. :file:`F90_ros_split` uses :command:`#FUNCTION SPLIT`.
+#. :file:`F90_ros_upcase` uses :command:`#UPPERCASEF90 ON`.
 #. :file:`F90_small_strato` is the example from
    :ref:`running-kpp-with-an-example-mechanism`.
 #. :file:`X_minver` tests if the :ref:`minversion-cmd` command works
@@ -544,17 +581,17 @@ local computer system.
 ci-cleanup-script.sh
 ~~~~~~~~~~~~~~~~~~~~
 
-**Path:** :file:`$KPP_HOME/.ci-pipelines/ci-cleanup-script.sh` 
+**Path:** :file:`$KPP_HOME/.ci-pipelines/ci-cleanup-script.sh`
 
 **Description:** Removes compiler-generated files (e.g. :file:`*.o`,
 :file:`.mod` , and  :file:`.exe`) from C-I test folders.
 
 .. _running-ci-tests-defs:
-      
+
 ci-common-defs.sh
 ~~~~~~~~~~~~~~~~~~
 
-**Path:** :file:`$KPP_HOME/.ci-pipelines/ci-common-defs.sh` 
+**Path:** :file:`$KPP_HOME/.ci-pipelines/ci-common-defs.sh`
 
 **Description** Contains common variable and function definitions needed by
 :ref:`running-ci-tests-testing` and :ref:`running-ci-tests-cleanup`.

--- a/docs/source/tech_info/07_numerical_methods.rst
+++ b/docs/source/tech_info/07_numerical_methods.rst
@@ -428,7 +428,7 @@ coupled linear systems of dimension (at most) :math:`n \times s`.
 
 The Runge-Kutta methods implemented in KPP are summarized below:
 
-.. _rk-method-comparison:
+.. _rk-methods-3stage:
 
 3-stage Runge-Kutta
 -------------------
@@ -442,6 +442,8 @@ Fully implicit 3-stage Runge-Kutta methods.  Several variants are available:
 - Lobatto-3C: order 4
 - Gauss: order 6
 
+.. _rk-methods-radau5:
+
 RADAU5
 ------
 **Integrator file:** :file:`int/radau5.f90`
@@ -452,6 +454,8 @@ implementation of :cite:t:`Hairer_and_Wanner_1991`, Section IV.10. While
 RADAU5 is relatively expensive (when compared to the Rosenbrock
 methods), it is more robust and is useful to obtain accurate reference
 solutions.
+
+.. _rk-methods-sdirk:
 
 SDIRK
 -----
@@ -465,12 +469,16 @@ variants are available:
   - Sdirk 3a: 3 stages, order 2
   - Sdirk 4a, 4b: 5 stages, order 4
 
+.. _rk-methods-sdirk4:
+
 SDIRK4
 ------
 **Integrator file:** :file:`int/sdirk4.f90`
 
 SDIRK4 is an L-stable, singly-diagonally-implicit Runge-Kutta method
 of order 4. The implementation is based on :cite:t:`Hairer_and_Wanner_1991`.
+
+.. _rk-methods-seulex:
 
 SEULEX
 ------
@@ -480,7 +488,7 @@ SEULEX is a variable  order stiff extrapolation code able to produce
 highly accurate solutions. The KPP implementation is based on the
 implementation of :cite:t:`Hairer_and_Wanner_1991`.
 
-.. _rk-tlm:
+.. _rk-methods-tlm:
 
 RK tangent linear model
 -----------------------
@@ -504,7 +512,7 @@ procedure. However, even for a SDIRK method (:math:`a_{ij}=0` for
 :math:`i>j` and :math:`a_{ii}=\gamma`) each stage requires the LU
 factorization of a different matrix.
 
-.. _rk-adj:
+.. _rk-methods-adj:
 
 RK discrete adjoint model
 -------------------------
@@ -553,6 +561,8 @@ such that the method has order of consistency :math:`k`.
 The KPP library contains two off-the-shelf, highly popular
 implementations of BDF methods, described in the following sections:
 
+.. _back-diff-lsode:
+
 LSODE
 -----
 **Integrator file:** :file:`int/lsode.f90`
@@ -571,6 +581,8 @@ been translated to Fortran90 for the incorporation into the KPP library.
    internal variables in LSODE will be overwritten by concurrent
    threads.
 
+.. _back-diff-vode:
+
 VODE
 ----
 
@@ -579,6 +591,8 @@ VODE
 VODE (:cite:t:`Brown_Byrne_and_Hindmarsh_1989`) uses another formulation
 of backward differentiation formulas. The version of VODE present in
 the KPP library uses directly the KPP sparse linear algebra routines.
+
+.. _back-diff-beuler:
 
 BEULER
 ------
@@ -599,6 +613,8 @@ in your definition file, and then set :code:`ICNTRL(3) = 6`.
 =========================
 Other integration methods
 =========================
+
+.. _other-methods-feuler:
 
 FEULER
 ------

--- a/docs/source/using_kpp/04_input_for_kpp.rst
+++ b/docs/source/using_kpp/04_input_for_kpp.rst
@@ -1878,7 +1878,7 @@ and :code:`ICNTRL(14) = 0`. Will be ignored if :code:`ICNTRL(14) > 0`.
 Different, solver-specific settings for :code:`seulex`.
 
 RCNTRL(13)
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~
 
 Solver-specific settings for :code:`seulex`.
 
@@ -1902,7 +1902,7 @@ Solver-specific settings for :code:`rosenbrock_h211b_qssa`.
 Different, solver-specific settings for :code:`seulex`.
 
 RCNTRL(19)
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~
 
 Solver-specific settings for :code:`seulex`.
 
@@ -1910,3 +1910,100 @@ RCNTRL(20)
 ~~~~~~~~~~
 
 Currently not used.
+
+.. _filter-passive-spc:
+
+==================================================================
+Filtering out passive species with an absolute tolerance threshold
+==================================================================
+
+In some external models that use KPP (such as GEOS-Chem) it is common
+to attach "passive" species to reactions.  This is usually done to
+optain production or loss rates for diagnostic purposes.
+
+We have created a simple passive species example C-I test (see the
+chemcial mechanism description file
+:file:`ci-tests/F90_ros_passivespc/F90_ros_passivespc.kpp`).  In this
+example we add 3 passive species (:literal:`PASV1`, :literal:`PASV2`,
+:literal:`PASV3`) are to the :literal:`small_strato` mechanism:
+
+.. code-block:: console
+
+   #EQUATIONS                         { SMALL STRATOSPHERIC MECHANISM           }
+   <R1>  O2   + hv = 2O               : (2.643E-10) * SUN*SUN*SUN;
+   <R2>  O    + O2 = O3               : (8.018E-17);
+   <R3>  O3   + hv = O   + O2         : (6.120E-04) * SUN;
+   <R4>  O    + O3 = 2O2              : (1.576E-15);
+   <R5>  O3   + hv = O1D + O2         : (1.070E-03) * SUN*SUN;
+   <R6>  O1D  + M  = O   + M          : (7.110E-11);
+   <R7>  O1D  + O3 = 2O2      + PASV1 : (1.200E-10);
+   <R8>  NO   + O3 = NO2 + O2 + PASV2 : (6.062E-15);
+   <R9>  NO2  + O  = NO  + O2         : (1.069E-11);
+   <R10> NO2  + hv = NO  + O  + PASV3 : (1.289E-02) * SUN;
+
+Passive species, however, should not be allowed to influence certain
+computations (such as the Rosenbrock error norm), as this may lead to
+numerical instability.  In the case of the Rosenbrock error norm, we
+have found that results of key species (such as O3 and NO) can vary
+depending on the number of passive species that are added to the
+mechanism.
+
+In KPP 3.5.0 we have introduced the capability to filter out passive
+species.  This feature is currently only available when generating
+Fortran90 source code with KPP.  You may do this as follows:
+
+First, give each passive species an extremely high absolute tolerance
+(:code:`ATOL`) value:
+
+.. code-block:: Fortran
+
+   USE ROOT_Parameters
+
+   ...
+
+   ATOL(ind_PASV1) = 1.0d25
+   ATOL(ind_PASV2) = 1.0d25
+   ATOL(ind_PASV3) = 1.0d25
+
+Next, pass the optional argument :code:`PassiveSpc_ATOL_Threshold` to
+the :ref:`Initialize <Initialize>` routine (this needs to be done
+only once at the model initialization phase):
+
+.. code-block:: Fortran
+
+   CALL Initialize( PassiveSpc_ATOL_Threshold = 1.0d25 )
+
+Any species having a value of :code:`ATOL` greater than or equal to
+:code:`PassiveSpc_ATOL_Threshold` will be denoted as a passive
+species. Subroutine :ref:`Initialize <Initialize>` will then generate
+the number and list of non-passive species in the following variables,
+which are stored in the :ref:`Global` module:
+
+.. code-block:: Fortran
+
+   ! NonPassiveSpc_Count - Number of non-passive species in mechanism
+     INTEGER :: NonPassiveSpc_Count
+   ! NonPassiveSpc_Indices - Indices of non-passive species in mechanism
+     INTEGER :: NonPassiveSpc_Indices(NVAR)
+
+You may then use these variables to exclude passive species from
+certain computations, such as:
+
+.. code-block:: Fortran
+
+   USE ROOT_Global
+
+   ...
+
+   INTEGER :: NP, I
+
+   ! Loop over the number of non-passive species
+   DO NP = 1, NonPassiveSpc_Count
+
+      ! Only use non-passive species in computation
+      I   = NonPassiveSpc_Indices(NP)
+      Err = ATOL(I) * RTOL(I) * YMAX
+
+      ... etc ...
+
+   ENDDO

--- a/docs/source/using_kpp/05_output_from_kpp.rst
+++ b/docs/source/using_kpp/05_output_from_kpp.rst
@@ -76,6 +76,15 @@ contains the subroutine :code:`Initialize`, which defines initial
 values of the chemical species. The driver calls the subroutine once
 before the time integration loop starts.
 
+.. note::
+
+   In KPP 3.5.0 and later versions, you may pass the optional
+   :code:`PassiveSpc_ATOL_Threshold` to subroutine :code:`Initialize`
+   to prevent "passive" species intended for diagnostic purposes from
+   being used in certain computations (such as the Rosenbrock error
+   norm).  At present this option is limited to Fortran90.  For more
+   information, please see the :ref:`filter-passive-spc` section.
+
 .. _Integrator:
 
 ROOT_Integrator
@@ -151,18 +160,19 @@ The code to update the rate constants is in :file:`ROOT_Rates.f90` (or
 
 .. _table-rat-fun:
 
-.. table:: Fortran90 subrotutines in ROOT_Rates
+.. list-table:: Fortran90 subrotutines in ROOT_Rates
    :align: center
+   :header-rows: 1
+   :widths: 25 75
 
-   +-----------------------+--------------------------------------+
-   | Function              | Description                          |
-   +=======================+======================================+
-   | :code:`Update_PHOTO`  | Update photolysis rate coefficients  |
-   +-----------------------+--------------------------------------+
-   | :code:`Update_RCONST` | Update all rate coefficients         |
-   +-----------------------+--------------------------------------+
-   | :code:`Update_SUN`    | Update sun intensity                 |
-   +-----------------------+--------------------------------------+
+   * - Function
+     - Description
+   * - :code:`Update_PHOTO`
+     - Update photolysis rate coefficients
+   * - :code:`Update_RCONST`
+     - Update all rate coefficients
+   * - :code:`Update_SUN`
+     - Update sun intensity
 
 .. _Parameters:
 
@@ -174,34 +184,47 @@ Global parameters are defined and initialized in
 
 .. _table-par:
 
-.. table:: Parameters Declared in ROOT_Parameters
+.. list-table:: Parameters Declared in ROOT_Parameters
    :align: center
+   :widths: 20 60 20
+   :header-rows: 1
 
-   +----------------+---------------------------------------------+---------+
-   | Parameter      | Represents                                  | Example |
-   +================+=============================================+=========+
-   | ``NSPEC``      | No. chemical species (``NVAR`` + ``NFIX``)  | 7       |
-   +----------------+---------------------------------------------+---------+
-   | ``NVAR``       | No. variable species                        | 5       |
-   +----------------+---------------------------------------------+---------+
-   | ``NFIX``       | No. fixed species                           | 2       |
-   +----------------+---------------------------------------------+---------+
-   | ``NREACT``     | No. reactions                               | 10      |
-   +----------------+---------------------------------------------+---------+
-   | ``NONZERO``    | No. nonzero entries Jacobian                | 18      |
-   +----------------+---------------------------------------------+---------+
-   | ``LU_NONZERO`` | As above, after LU factorization            | 19      |
-   +----------------+---------------------------------------------+---------+
-   | ``NHESS``      | Length, sparse Hessian                      | 10      |
-   +----------------+---------------------------------------------+---------+
-   | ``NJVRP``      | Length, sparse Jacobian JVRP                | 13      |
-   +----------------+---------------------------------------------+---------+
-   | ``NSTOICM``    | Length, stoichiometric matrix               | 22      |
-   +----------------+---------------------------------------------+---------+
-   | ``ind_spc``    | Index of species *spc* in :code:`C`         |         |
-   +----------------+---------------------------------------------+---------+
-   | ``indf_spc``   | Index of fixed species *spc* in :code:`FIX` |         |
-   +----------------+---------------------------------------------+---------+
+   * - Parameter
+     - Represents
+     - Example
+   * - ``NSPEC``
+     - No. chemical species (``NVAR`` + ``NFIX``)
+     - 7
+   * - ``NVAR``
+     - No. variable species
+     - 5
+   * - ``NFIX``
+     - No. fixed species
+     - 2
+   * - ``NREACT``
+     - No. reactions
+     - 10
+   * - ``NONZERO``
+     - No. nonzero entries Jacobian
+     - 18
+   * - ``LU_NONZERO``
+     - As above, after LU factorization
+     - 19
+   * - ``NHESS``
+     - Length, sparse Hessian
+     - 10
+   * - ``NJVRP``
+     - Length, sparse Jacobian JVRP
+     - 13
+   * - ``NSTOICM``
+     - Length, stoichiometric matrix
+     - 22
+   * - ``ind_spc``
+     - Index of species *spc* in :code:`C`
+     -
+   * - ``indf_spc``
+     - Index of fixed species *spc* in :code:`FIX`
+     -
 
 Example values listed in the 3rd column are taken from the
 :program:`small_strato` mechanism (cf.
@@ -236,40 +259,41 @@ Several global variables are declared in :file:`ROOT_Global.f90` (or
 
 .. _table-glob:
 
-.. table:: Global Variables Declared in ROOT_Global
+.. list-table:: Global Variables Declared in ROOT_Global
    :align: center
+   :widths: 35 65
+   :header-rows: 1
 
-   +-------------------------+---------------------------------------------+
-   | Global variable         | Represents                                  |
-   +=========================+=============================================+
-   | :code:`C(NSPEC)`        | Concentrations, all species                 |
-   +-------------------------+---------------------------------------------+
-   | :code:`VAR(:)`          | Concentrations, variable species (pointer)  |
-   +-------------------------+---------------------------------------------+
-   | :code:`FIX(:)`          | Concentrations, fixed species (pointer)     |
-   +-------------------------+---------------------------------------------+
-   | :code:`RCONST(NREACT)`  | Rate coefficient values                     |
-   +-------------------------+---------------------------------------------+
-   | :code:`TIME`            | Current integration time                    |
-   +-------------------------+---------------------------------------------+
-   | :code:`SUN`             | Sun intensity between 0 and 1               |
-   +-------------------------+---------------------------------------------+
-   | :code:`TEMP`            | Temperature                                 |
-   +-------------------------+---------------------------------------------+
-   | :code:`TSTART, TEND`    | Simulation start/end time                   |
-   +-------------------------+---------------------------------------------+
-   | :code:`DT`              | Simulation time step                        |
-   +-------------------------+---------------------------------------------+
-   | :code:`ATOL(NSPEC)`     | Absolute tolerances                         |
-   +-------------------------+---------------------------------------------+
-   | :code:`RTOL(NSPEC)`     | Relative tolerances                         |
-   +-------------------------+---------------------------------------------+
-   | :code:`STEPMIN`         | Lower bound for time step                   |
-   +-------------------------+---------------------------------------------+
-   | :code:`STEPMAX`         | Upper bound for time step                   |
-   +-------------------------+---------------------------------------------+
-   | :code:`CFACTOR`         | Conversion factor                           |
-   +-------------------------+---------------------------------------------+
+   * - Global variable
+     - Represents
+   * - :code:`C(NSPEC)`
+     - Concentrations, all species
+   * - :code:`VAR(:)`
+     - Concentrations, variable species (pointer)
+   * - :code:`FIX(:)`
+     - Concentrations, fixed species (pointer)
+   * - :code:`RCONST(NREACT)`
+     - Rate coefficient values
+   * - :code:`TIME`
+     - Current integration time
+   * - :code:`SUN`
+     - Sun intensity between 0 and 1
+   * - :code:`TEMP`
+     - Temperature
+   * - :code:`TSTART, TEND`
+     - Simulation start/end time
+   * - :code:`DT`
+     - Simulation time step
+   * - :code:`ATOL(NSPEC)`
+     - Absolute tolerances
+   * - :code:`RTOL(NSPEC)`
+     - Relative tolerances
+   * - :code:`STEPMIN`
+     - Lower bound for time step
+   * - :code:`STEPMAX`
+     - Upper bound for time step
+   * - :code:`CFACTOR`
+     - Conversion factor
 
 Both variable and fixed species are stored in the one-dimensional
 array :code:`C`. The first part (indices from :code:`1` to :code:`NVAR`)
@@ -438,22 +462,23 @@ fill-in is accounted for) are:
 
 .. _table-jac:
 
-.. table:: Sparse Jacobian Data Structures
+.. list-table:: Sparse Jacobian Data Structures
    :align: center
+   :widths: 35 65
+   :header-rows: 1
 
-   +------------------------------+-------------------------------------+
-   | Global variable              | Represents                          |
-   +==============================+=====================================+
-   | :code:`JVS(LU_NONZERO)`      | Jacobian nonzero elements           |
-   +------------------------------+-------------------------------------+
-   | :code:`LU_IROW(LU_NONZERO)`  | Row indices                         |
-   +------------------------------+-------------------------------------+
-   | :code:`LU_ICOL(LU_NONZERO)`  | Column indices                      |
-   +------------------------------+-------------------------------------+
-   | :code:`LU_CROW(NVAR+1)`      | Start of rows                       |
-   +------------------------------+-------------------------------------+
-   | :code:`LU_DIAG(NVAR+1)`      | Diagonal entries                    |
-   +------------------------------+-------------------------------------+
+   * - Global variable
+     - Represents
+   * - :code:`JVS(LU_NONZERO)`
+     - Jacobian nonzero elements
+   * - :code:`LU_IROW(LU_NONZERO)`
+     - Row indices
+   * - :code:`LU_ICOL(LU_NONZERO)`
+     - Column indices
+   * - :code:`LU_CROW(NVAR+1)`
+     - Start of rows
+   * - :code:`LU_DIAG(NVAR+1)`
+     - Diagonal entries
 
 :code:`JVS` stores the :code:`LU_NONZERO` elements of the
 Jacobian in row order. Each row :code:`I` starts at position
@@ -499,20 +524,21 @@ user-supplied vector :code:`UV` without any indirect addressing.
 
 .. _table-jac-fun:
 
-.. table:: Fortran90 subroutines in ROOT_Jacobian
+.. list-table:: Fortran90 subroutines in ROOT_Jacobian
    :align: center
+   :widths: 30 70
+   :header-rows: 1
 
-   +----------------------+----------------------------------------------+
-   | Function             | Description                                  |
-   +======================+==============================================+
-   | :code:`Jac_SP`       | ODE Jacobian in sparse format                |
-   +----------------------+----------------------------------------------+
-   | :code:`Jac_SP_Vec`   | Sparse multiplication                        |
-   +----------------------+----------------------------------------------+
-   | :code:`JacTR_SP_Vec` | Sparse multiplication                        |
-   +----------------------+----------------------------------------------+
-   | :code:`Jac`          | ODE Jacobian in full format                  |
-   +----------------------+----------------------------------------------+
+   * - Function
+     - Description
+   * - :code:`Jac_SP`
+     - ODE Jacobian in sparse format
+   * - :code:`Jac_SP_Vec`
+     - Sparse multiplication
+   * - :code:`JacTR_SP_Vec`
+     - Sparse multiplication
+   * - :code:`Jac`
+     - ODE Jacobian in full format
 
 .. _Hessian-and-HessianSP:
 
@@ -537,18 +563,19 @@ KPP generates the routine :code:`Hessian`:
 
 .. _table-hess-fun:
 
-.. table:: Fortran90 functions in ROOT_Hessian
+.. list-table:: Fortran90 functions in ROOT_Hessian
    :align: center
+   :widths: 30 70
+   :header-rows: 1
 
-   +--------------------+--------------------------------------+
-   | Function           | Description                          |
-   +====================+======================================+
-   | :code:`Hessian`    | ODE Hessian in sparse format         |
-   +--------------------+--------------------------------------+
-   | :code:`Hess_Vec`   | Hessian action on vectors            |
-   +--------------------+--------------------------------------+
-   | :code:`HessTR_Vec` | Transposed Hessian action on vectors |
-   +--------------------+--------------------------------------+
+   * - Function
+     - Description
+   * - :code:`Hessian`
+     - ODE Hessian in sparse format
+   * - :code:`Hess_Vec`
+     - Hessian action on vectors
+   * - :code:`HessTR_Vec`
+     - Transposed Hessian action on vectors
 
 Using the variable species :code:`V`, the fixed species :code:`F`, and
 the rate coefficients :code:`RCT` as input, the subroutine
@@ -572,20 +599,21 @@ hold the indices of nonzero entries as illustrated in :ref:`table-hess`.
 
 .. _table-hess:
 
-.. table:: Sparse Hessian Data
+.. list-table:: Sparse Hessian Data
    :align: center
+   :widths: 35 65
+   :header-rows: 1
 
-   +-------------------------+----------------------------------------------+
-   | Variable                | Represents                                   |
-   +=========================+==============================================+
-   | :code:`HESS(NHESS)`     | Hessian nonzero elements :math:`H_{i,j,k}`   |
-   +-------------------------+----------------------------------------------+
-   | :code:`IHESS_I(NHESS)`  | Index :math:`i` of element :math:`H_{i,j,k}` |
-   +-------------------------+----------------------------------------------+
-   | :code:`IHESS_J(NHESS)`  | Index :math:`j` of element :math:`H_{i,j,k}` |
-   +-------------------------+----------------------------------------------+
-   | :code:`IHESS_J(NHESS)`  | Index :math:`k` of element :math:`H_{i,j,k}` |
-   +-------------------------+----------------------------------------------+
+   * - Variable
+     - Represents
+   * - :code:`HESS(NHESS)`
+     - Hessian nonzero elements :math:`H_{i,j,k}`
+   * - :code:`IHESS_I(NHESS)`
+     - Index :math:`i` of element :math:`H_{i,j,k}`
+   * - :code:`IHESS_J(NHESS)`
+     - Index :math:`j` of element :math:`H_{i,j,k}`
+   * - :code:`IHESS_K(NHESS)`
+     - Index :math:`k` of element :math:`H_{i,j,k}`
 
 Since the time derivative function is smooth, these Hessian matrices
 are symmetric, :math:`\tt HESS_{i,j,k}`\ =\ :math:`\tt HESS_{i,k,j}`.
@@ -634,18 +662,19 @@ returns a value that is nonzero if singularity is detected.
 
 .. _table-la-fun:
 
-.. table:: Fortran90 functions in ROOT_LinearAlgebra
+.. list-table:: Fortran90 functions in ROOT_LinearAlgebra
    :align: center
+   :widths: 30 70
+   :header-rows: 1
 
-   +--------------------+--------------------------------------+
-   | Function           | Description                          |
-   +====================+======================================+
-   | :code:`KppDecomp`  | Sparse LU decomposition              |
-   +--------------------+--------------------------------------+
-   | :code:`KppSolve`   | Sparse back subsitution              |
-   +--------------------+--------------------------------------+
-   | :code:`KppSolveTR` | Transposed sparse back substitution  |
-   +--------------------+--------------------------------------+
+   * - Function
+     - Description
+   * - :code:`KppDecomp`
+     - Sparse LU decomposition
+   * - :code:`KppSolve`
+     - Sparse back substitution
+   * - :code:`KppSolveTR`
+     - Transposed sparse back substitution
 
 The subroutines :code:`KppSolve` and :code:`KppSolveTr` and use the
 in-place LU factorization :math:`P` as computed by and perform sparse
@@ -690,37 +719,39 @@ vector at position :code:`CCOL_STOICM(j)` and ends at
 
 .. _table-sto:
 
-.. table:: Sparse Stoichiometric Matrix
+.. list-table:: Sparse Stoichiometric Matrix
    :align: center
+   :widths: 35 65
+   :header-rows: 1
 
-   +-------------------------------+-----------------------------------------+
-   | Variable                      | Represents                              |
-   +===============================+=========================================+
-   | :code:`STOICM(NSTOICM)`       | Stoichiometric matrix                   |
-   +-------------------------------+-----------------------------------------+
-   | :code:`IROW_STOICM(NSTOICM)`  | Row indices                             |
-   +-------------------------------+-----------------------------------------+
-   | :code:`ICOL_STOICM(NSTOICM)`  | Column indices                          |
-   +-------------------------------+-----------------------------------------+
-   | :code:`CCOL_STOICM(NREACT+1)` | Start of columns                        |
-   +-------------------------------+-----------------------------------------+
+   * - Variable
+     - Represents
+   * - :code:`STOICM(NSTOICM)`
+     - Stoichiometric matrix
+   * - :code:`IROW_STOICM(NSTOICM)`
+     - Row indices
+   * - :code:`ICOL_STOICM(NSTOICM)`
+     - Column indices
+   * - :code:`CCOL_STOICM(NREACT+1)`
+     - Start of columns
 
 .. _table-sto-fun:
 
-.. table:: Fortran90 functions in ROOT_Stoichiom
+.. list-table:: Fortran90 functions in ROOT_Stoichiom
    :align: center
+   :widths: 35 65
+   :header-rows: 1
 
-   +-------------------------+--------------------------------------------+
-   | Variable                | Represents                                 |
-   +=========================+============================================+
-   | :code:`dFun_dRcoeff`    | Derivatives of Fun w/r/t rate coefficients |
-   +-------------------------+--------------------------------------------+
-   | :code:`dJac_dRcoeff`    | Derivatives of Jac w/r/t rate coefficients |
-   +-------------------------+--------------------------------------------+
-   | :code:`ReactantProd`    | Reactant products                          |
-   +-------------------------+--------------------------------------------+
-   | :code:`JacReactantProd` | Jacobian of reactant products              |
-   +-------------------------+--------------------------------------------+
+   * - Variable
+     - Represents
+   * - :code:`dFun_dRcoeff`
+     - Derivatives of Fun w/r/t rate coefficients
+   * - :code:`dJac_dRcoeff`
+     - Derivatives of Jac w/r/t rate coefficients
+   * - :code:`ReactantProd`
+     - Reactant products
+   * - :code:`JacReactantProd`
+     - Jacobian of reactant products
 
 The subroutine :code:`ReactantProd` (see :ref:`table-sto-fun`)
 computes the reactant products :code:`ARP` for each reaction, and the
@@ -746,20 +777,21 @@ parameter :code:`NJVRP` holds the number of nonzero elements. For our
 
 .. _table-jvrp:
 
-.. table:: Sparse Data for Jacobian of Reactant Products
+.. list-table:: Sparse Data for Jacobian of Reactant Products
    :align: center
+   :widths: 35 65
+   :header-rows: 1
 
-   +-------------------------------+-----------------------------------------+
-   | Variable                      | Represents                              |
-   +===============================+=========================================+
-   | :code:`JVRP(NJVRP)`           | Nonzero elements of :code:`JVRP`        |
-   +-------------------------------+-----------------------------------------+
-   | :code:`ICOL_JVRP(NJVRP)`      | Column indices of :code:`JVRP`          |
-   +-------------------------------+-----------------------------------------+
-   | :code:`IROW_JVRP(NJVRP)`      | Row indices of :code:`JVRP`             |
-   +-------------------------------+-----------------------------------------+
-   | :code:`CROW_JVRP(NREACT+1)`   | Start of rows in :code:`JVRP`           |
-   +-------------------------------+-----------------------------------------+
+   * - Variable
+     - Represents
+   * - :code:`JVRP(NJVRP)`
+     - Nonzero elements of :code:`JVRP`
+   * - :code:`ICOL_JVRP(NJVRP)`
+     - Column indices of :code:`JVRP`
+   * - :code:`IROW_JVRP(NJVRP)`
+     - Row indices of :code:`JVRP`
+   * - :code:`CROW_JVRP(NREACT+1)`
+     - Start of rows in :code:`JVRP`
 
 If :command:`#STOICMAT` is set to :command:`ON`, the stoichiometric
 formulation allows a direct computation of the derivatives with
@@ -834,28 +866,29 @@ KPP generates several utility subroutines and functions in the file
 
 .. _table-util-fun:
 
-.. table:: Fortran90 subroutines and functions in ROOT_Util
+.. list-table:: Fortran90 subroutines and functions in ROOT_Util
    :align: center
+   :widths: 30 70
+   :header-rows: 1
 
-   +-----------------------------------+---------------------------------------------+
-   | Function                          | Description                                 |
-   +===================================+=============================================+
-   | :code:`GetMass`                   | Check mass balance for selected atoms       |
-   +-----------------------------------+---------------------------------------------+
-   | :code:`Shuffle_kpp2user`          | Shuffle concentration vector                |
-   +-----------------------------------+---------------------------------------------+
-   | :code:`Shuffle_user2kpp`          | Shuffle concentration vector                |
-   +-----------------------------------+---------------------------------------------+
-   | :code:`InitSaveData`              | Utility for :command:`#LOOKAT` command      |
-   +-----------------------------------+---------------------------------------------+
-   | :code:`SaveData`                  | Utility for :command:`#LOOKAT` command      |
-   +-----------------------------------+---------------------------------------------+
-   | :code:`CloseSaveData`             | Utility for :command:`#LOOKAT` command      |
-   +-----------------------------------+---------------------------------------------+
-   | :code:`tag2num`                   | Calculate reaction number from equation tag |
-   +-----------------------------------+---------------------------------------------+
-   | :code:`Integrator_Update_Options` | Choose :code:`Update_RCONST/PHOTO/SUN`      |
-   +-----------------------------------+---------------------------------------------+
+   * - Function
+     - Description
+   * - :code:`GetMass`
+     - Check mass balance for selected atoms
+   * - :code:`Shuffle_kpp2user`
+     - Shuffle concentration vector
+   * - :code:`Shuffle_user2kpp`
+     - Shuffle concentration vector
+   * - :code:`InitSaveData`
+     - Utility for :command:`#LOOKAT` command
+   * - :code:`SaveData`
+     - Utility for :command:`#LOOKAT` command
+   * - :code:`CloseSaveData`
+     - Utility for :command:`#LOOKAT` command
+   * - :code:`tag2num`
+     - Calculate reaction number from equation tag
+   * - :code:`Integrator_Update_Options`
+     - Choose :code:`Update_RCONST/PHOTO/SUN`
 
 The subroutines :code:`InitSaveData`, :code:`SaveData`, and
 :code:`CloseSaveData` can be used to print the concentration of the
@@ -1014,65 +1047,63 @@ format into a Matlab sparse matrix.
 
 .. _table-matlab:
 
-.. table:: List of Matlab model files
+.. list-table:: List of Matlab model files
    :align: center
+   :widths: 35 65
+   :header-rows: 1
 
-   +----------------------------------+-------------------------------------+
-   | Function                         | Description                         |
-   +==================================+=====================================+
-   | :file:`ROOT.m`                   | Driver                              |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_parameter_defs.m`    | Global parameters                   |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_global_defs.m`       | Global variables                    |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_sparse_defs.m`       | Global sparsity data                |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_Fun_Chem.m`          | Template for ODE function           |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_Fun.m`               | ODE function                        |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_Jac_Chem.m`          | Template for ODE Jacobian           |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_Jac_SP.m`            | Jacobian in sparse format           |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_JacobianSP.m`        | Sparsity data structures            |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_Hessian.m`           | ODE Hessian in sparse format        |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_HessianSP.m`         | Sparsity data structures            |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_Hess_Vec.m`          | Hessian action on vectors           |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_HessTR_Vec.m`        | Transposed Hessian action on        |
-   |                                  | vectors                             |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_stoichiom.m`         | Derivatives of Fun and Jac w/r/t    |
-   |                                  | rate coefficients                   |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_stochiomSP.m`        | Sparse data                         |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_ReactantProd.m`      | Reactant products                   |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_JacReactantProd.m`   | Jacobian of reactant products       |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_Rates.m`             | User-defined rate reaction laws     |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_Update_PHOTO.m`      | Update photolysis rate coefficients |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_Update_RCONST.m`     | Update all rate coefficients        |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_Update_SUN.m`        | Update sola intensity               |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_GetMass.m`           | Check mass balance for selected     |
-   |                                  | atoms                               |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_Initialize.m`        | Set initial values                  |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_Shuffle_kpp2user.m`  | Shuffle concentration vector        |
-   +----------------------------------+-------------------------------------+
-   | :file:`ROOT_Shuffle_user2kpp.m`  | Shuffle concentration vector        |
-   +----------------------------------+-------------------------------------+
+   * - Function
+     - Description
+   * - :file:`ROOT.m`
+     - Driver
+   * - :file:`ROOT_parameter_defs.m`
+     - Global parameters
+   * - :file:`ROOT_global_defs.m`
+     - Global variables
+   * - :file:`ROOT_sparse_defs.m`
+     - Global sparsity data
+   * - :file:`ROOT_Fun_Chem.m`
+     - Template for ODE function
+   * - :file:`ROOT_Fun.m`
+     - ODE function
+   * - :file:`ROOT_Jac_Chem.m`
+     - Template for ODE Jacobian
+   * - :file:`ROOT_Jac_SP.m`
+     - Jacobian in sparse format
+   * - :file:`ROOT_JacobianSP.m`
+     - Sparsity data structures
+   * - :file:`ROOT_Hessian.m`
+     - ODE Hessian in sparse format
+   * - :file:`ROOT_HessianSP.m`
+     - Sparsity data structures
+   * - :file:`ROOT_Hess_Vec.m`
+     - Hessian action on vectors
+   * - :file:`ROOT_HessTR_Vec.m`
+     - Transposed Hessian action on vectors
+   * - :file:`ROOT_stoichiom.m`
+     - Derivatives of Fun and Jac w/r/t rate coefficients
+   * - :file:`ROOT_stoichiomSP.m`
+     - Sparse data
+   * - :file:`ROOT_ReactantProd.m`
+     - Reactant products
+   * - :file:`ROOT_JacReactantProd.m`
+     - Jacobian of reactant products
+   * - :file:`ROOT_Rates.m`
+     - User-defined rate reaction laws
+   * - :file:`ROOT_Update_PHOTO.m`
+     - Update photolysis rate coefficients
+   * - :file:`ROOT_Update_RCONST.m`
+     - Update all rate coefficients
+   * - :file:`ROOT_Update_SUN.m`
+     - Update sola intensity
+   * - :file:`ROOT_GetMass.m`
+     - Check mass balance for selected atoms
+   * - :file:`ROOT_Initialize.m`
+     - Set initial values
+   * - :file:`ROOT_Shuffle_kpp2user.m`
+     - Shuffle concentration vector
+   * - :file:`ROOT_Shuffle_user2kpp.m`
+     - Shuffle concentration vector
 
 .. _Makefile:
 
@@ -1144,27 +1175,29 @@ ISTATUS
    +----------------------------+---+---+---+---+---+---+---+---+---+
    | radau5                     | Y | Y | Y | Y | Y | Y | Y | Y |   |
    +----------------------------+---+---+---+---+---+---+---+---+---+
-   | rosenbrock_adj             | Y | Y | Y | Y | Y | Y | Y | Y |   |
-   +----------------------------+---+---+---+---+---+---+---+---+---+
    | rosenbrock                 | Y | Y | Y | Y | Y | Y | Y | Y |   |
    +----------------------------+---+---+---+---+---+---+---+---+---+
-   | rosenbrock_tlm             | Y | Y | Y | Y | Y | Y | Y | Y | Y |
+   | rosenbrock_adj             | Y | Y | Y | Y | Y | Y | Y | Y |   |
    +----------------------------+---+---+---+---+---+---+---+---+---+
    | rosenbrock_autoreduce      | Y | Y | Y | Y | Y | Y | Y | Y |   |
    +----------------------------+---+---+---+---+---+---+---+---+---+
-   | runge_kutta_adj            | Y | Y | Y | Y | Y | Y | Y | Y |   |
+   | rosenbrock_h211b_qssa      | Y | Y | Y | Y | Y | Y | Y | Y |   |
+   +----------------------------+---+---+---+---+---+---+---+---+---+
+   | rosenbrock_tlm             | Y | Y | Y | Y | Y | Y | Y | Y | Y |
    +----------------------------+---+---+---+---+---+---+---+---+---+
    | runge_kutta                | Y | Y | Y | Y | Y | Y | Y | Y |   |
    +----------------------------+---+---+---+---+---+---+---+---+---+
+   | runge_kutta_adj            | Y | Y | Y | Y | Y | Y | Y | Y |   |
+   +----------------------------+---+---+---+---+---+---+---+---+---+
    | runge_kutta_tlm            | Y | Y | Y | Y | Y | Y | Y | Y |   |
-   +----------------------------+---+---+---+---+---+---+---+---+---+
-   | sdirk4                     | Y | Y | Y | Y | Y | Y | Y | Y |   |
-   +----------------------------+---+---+---+---+---+---+---+---+---+
-   | sdirk_adj                  | Y | Y | Y | Y | Y | Y | Y | Y |   |
    +----------------------------+---+---+---+---+---+---+---+---+---+
    | sdirk                      | Y | Y | Y | Y | Y | Y | Y | Y |   |
    +----------------------------+---+---+---+---+---+---+---+---+---+
+   | sdirk_adj                  | Y | Y | Y | Y | Y | Y | Y | Y |   |
+   +----------------------------+---+---+---+---+---+---+---+---+---+
    | sdirk_tlm                  | Y | Y | Y | Y | Y | Y | Y | Y |   |
+   +----------------------------+---+---+---+---+---+---+---+---+---+
+   | sdirk4                     | Y | Y | Y | Y | Y | Y | Y | Y |   |
    +----------------------------+---+---+---+---+---+---+---+---+---+
    | seulex                     | Y | Y | Y | Y | Y | Y | Y |   |   |
    +----------------------------+---+---+---+---+---+---+---+---+---+
@@ -1248,27 +1281,29 @@ RSTATUS
    +----------------------------+---+---+---+---+
    | radau5                     |   |   |   |   |
    +----------------------------+---+---+---+---+
-   | rosenbrock_adj             | Y | Y | Y |   |
-   +----------------------------+---+---+---+---+
    | rosenbrock                 | Y | Y | Y |   |
    +----------------------------+---+---+---+---+
-   | rosenbrock_tlm             | Y | Y | Y |   |
+   | rosenbrock_adj             | Y | Y | Y |   |
    +----------------------------+---+---+---+---+
    | rosenbrock_autoreduce      | Y | Y | Y | s |
    +----------------------------+---+---+---+---+
-   | runge_kutta_adj            | Y | Y | Y |   |
+   | rosenbrock_h211b_qssa      | Y | Y | Y |   |
+   +----------------------------+---+---+---+---+
+   | rosenbrock_tlm             | Y | Y | Y |   |
    +----------------------------+---+---+---+---+
    | runge_kutta                | Y | Y | Y |   |
    +----------------------------+---+---+---+---+
+   | runge_kutta_adj            | Y | Y | Y |   |
+   +----------------------------+---+---+---+---+
    | runge_kutta_tlm            | Y | Y | Y |   |
-   +----------------------------+---+---+---+---+
-   | sdirk4                     | Y | Y |   |   |
-   +----------------------------+---+---+---+---+
-   | sdirk_adj                  | Y | Y | Y |   |
    +----------------------------+---+---+---+---+
    | sdirk                      | Y | Y | Y |   |
    +----------------------------+---+---+---+---+
+   | sdirk_adj                  | Y | Y | Y |   |
+   +----------------------------+---+---+---+---+
    | sdirk_tlm                  | Y | Y | Y |   |
+   +----------------------------+---+---+---+---+
+   | sdirk4                     | Y | Y |   |   |
    +----------------------------+---+---+---+---+
    | seulex                     |   |   |   |   |
    +----------------------------+---+---+---+---+

--- a/drv/general_passivespc.f90
+++ b/drv/general_passivespc.f90
@@ -1,0 +1,78 @@
+PROGRAM KPP_ROOT_Driver
+
+!~~~> Global variables and routines
+      USE KPP_ROOT_Model
+      USE KPP_ROOT_Initialize, ONLY: Initialize
+
+!~~~> Local variables
+      KPP_REAL :: T, DVAL(NSPEC)
+      KPP_REAL :: RSTATE(20)
+      INTEGER :: i
+
+!~~~> Control (in) arguments for the integration
+!~~~> These are set to zero by default, which will invoke default behavior
+      INTEGER :: ICNTRL(20)
+      KPP_REAL :: RCNTRL(20)
+
+      ICNTRL  = 0
+      RCNTRL  = 0.d0
+
+!~~~> Initialization
+      STEPMIN = 0.0d0
+      STEPMAX = 0.0d0
+
+      DO i=1,NVAR
+        RTOL(i) = 1.0d-4
+        ATOL(i) = 1.0d-3
+      END DO
+
+!~~~> Set default species concentrations
+!~~~> Species having a greater ATOL than PassiveSpc_ATOL_Threshold
+!~~~> will be considered passive and not be included in certain
+!~~~> calculations (such as the Rosenbrock error norm)
+      CALL Initialize( PassiveSpc_ATOL_Threshold = 1.0d25 )
+
+!~~~> Open log file for write
+      CALL InitSaveData()
+
+!~~~> Time loop
+      T = TSTART
+kron: DO WHILE (T < TEND)
+
+        TIME = T
+
+!~~~> Write values of monitored species at each iteration
+        CALL GetMass( C, DVAL )
+        WRITE(6,991) (T-TSTART)/(TEND-TSTART)*100, T,       &
+                   ( TRIM(SPC_NAMES(MONITOR(i))),           &
+                     C(MONITOR(i))/CFACTOR, i=1,NMONITOR )
+        CALL SaveData()
+
+!~~~> Update sunlight intensity and reaction rates
+!~~~> before calling the integrator.
+        CALL Update_SUN()
+        CALL Update_RCONST()
+
+!~~~> Call the integrator
+        CALL INTEGRATE( TIN       = T,        &
+                        TOUT      = T+DT,     &
+                        ICNTRL_U  = ICNTRL,   &
+                        RCNTRL_U  = RCNTRL,   &
+                        RSTATUS_U = RSTATE   )
+        T = RSTATE(1)
+
+      END DO kron
+!~~~> End Time loop
+
+!~~~> Write final values of monitored species and close log file
+      CALL GetMass( C, DVAL )
+      WRITE(6,991) (T-TSTART)/(TEND-TSTART)*100, T,     &
+               ( TRIM(SPC_NAMES(MONITOR(i))),           &
+                 C(MONITOR(i))/CFACTOR, i=1,NMONITOR )
+      TIME = T
+      CALL SaveData()
+      CALL CloseSaveData()
+
+991   FORMAT(F6.1,'%. T=',E9.3,2X,200(A,'=',E11.4,'; '))
+
+END PROGRAM KPP_ROOT_Driver

--- a/int/rosenbrock.f90
+++ b/int/rosenbrock.f90
@@ -166,7 +166,7 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
 !-    RCNTRL(1:20)    = real inputs parameters
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !
-!~~~>     OUTPUT ARGUMENTS:
+!~~~>   OUTPUT ARGUMENTS:
 !
 !-    Y(N)    -> vector of final states (at T->Tend)
 !-    ISTATUS(1:20)   -> integer output parameters
@@ -176,56 +176,71 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
 !                        failure (negative value)
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !
-!~~~>     INPUT PARAMETERS:
+!~~~>   INPUT PARAMETERS:
 !
 !    Note: For input parameters equal to zero the default values of the
-!       corresponding variables are used.
+!          corresponding variables are used.
 !
-!    ICNTRL(1) = 1: F = F(y)   Independent of T (AUTONOMOUS)
-!              = 0: F = F(t,y) Depends on T (NON-AUTONOMOUS)
+!    ICNTRL(1)  -> Specify time-dependence of the function to be integrated
+!        =  0 :    F = F(t,y) Depends on T (NON-AUTONOMOUS)
+!        =  1 :    F = F(y)   Independent of T (AUTONOMOUS)
 !
-!    ICNTRL(2) = 0: AbsTol, RelTol are N-dimensional vectors
-!              = 1: AbsTol, RelTol are scalars
+!    ICNTRL(2)  -> Specify vector or scalar tolerances
+!        =  0 :    AbsTol, RelTol are N-dimensional vectors
+!        =  1 :    AbsTol, RelTol are scalars
 !
-!    ICNTRL(3)  -> selection of a particular Rosenbrock method
-!        = 0 :    Rodas3 (default)
-!        = 1 :    Ros2
-!        = 2 :    Ros3
-!        = 3 :    Ros4
-!        = 4 :    Rodas3
-!        = 5 :    Rodas4
-!        = 6 :    Rang3
-!        = 7 :    Rodas3.1
+!    ICNTRL(3)  -> Select a particular Rosenbrock method
+!        =  0 :    Rodas3 (default)
+!        =  1 :    Ros2
+!        =  2 :    Ros3
+!        =  3 :    Ros4
+!        =  4 :    Rodas3
+!        =  5 :    Rodas4
+!        =  6 :    Rang3
+!        =  7 :    Rodas3.1
 !
-!    ICNTRL(4)  -> maximum number of integration steps
-!        For ICNTRL(4)=0) the default value of 200000 is used
+!    ICNTRL(4)  -> Specify maximum number of integration steps
+!        =  0 :    Use up to 20000 integration steps (default)
+!        =  X :    Use up to X integration steps (X = any integer)
 !
-!    ICNTRL(15) -> Toggles calling of Update_* functions w/in the integrator
-!        = -1 :  Do not call Update_* functions within the integrator
-!        =  0 :  Status quo
-!        =  1 :  Call Update_RCONST from within the integrator
-!        =  2 :  Call Update_PHOTO from within the integrator
-!        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
-!        =  4 :  Call Update_SUN from within the integrator
-!        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
-!        =  7 :  Call Update_SUN, Update_PHOTO, Update_RCONST w/in the int.
+!    ICNTRL(15) -> Toggle calling of Update_* functions w/in the integrator
+!        = -1 :    Do not call Update_* functions within the integrator
+!        =  0 :    Status quo
+!        =  1 :    Call Update_RCONST from within the integrator
+!        =  2 :    Call Update_PHOTO from within the integrator
+!        =  3 :    Call Update_RCONST and Update_PHOTO from w/in the int.
+!        =  4 :    Call Update_SUN from within the integrator
+!        =  5 :    Call Update_SUN and Update_RCONST from within the int.
+!        =  6 :    Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :    Call Update_SUN, Update_PHOTO, Update_RCONST w/in the int.
 !
-!    ICNTRL(16) ->
-!        = 0 : allow negative concentrations (default)
-!        = 1 : set negative concentrations to zero
+!    ICNTRL(16) -> Specify how negative concentrations are handled
+!        =  0 :    Allow negative concentrations (default)
+!        =  1 :    Aet negative concentrations to zero
 !
-!    RCNTRL(1)  -> Hmin, lower bound for the integration step size
-!          It is strongly recommended to keep Hmin = ZERO
+!    ICNTRL(19) -> Specify # of species to use when computing the error norm
+!        =  0 :    Use N species (default)
+!        =  X :    Use N-X species, where X is the number of "dummy" species
+!                  (i.e. species added to reactions for diagnostic purposes).
+!
+!    RCNTRL(1)  -> Hmin, lower bound for the integration step size.
+!                  It is strongly recommended to keep Hmin = ZERO
+!
 !    RCNTRL(2)  -> Hmax, upper bound for the integration step size
+!
 !    RCNTRL(3)  -> Hstart, starting value for the integration step size
 !
-!    RCNTRL(4)  -> FacMin, lower bound on step decrease factor (default=0.2)
-!    RCNTRL(5)  -> FacMax, upper bound on step increase factor (default=6)
+!    RCNTRL(4)  -> FacMin, lower bound on step decrease factor 
+!                  (default = 0.2)
+!
+!    RCNTRL(5)  -> FacMax, upper bound on step increase factor
+!                  (default = 6)
+!
 !    RCNTRL(6)  -> FacRej, step decrease factor after multiple rejections
-!                          (default=0.1)
+!                  (default = 0.1)
+!
 !    RCNTRL(7)  -> FacSafe, by which the new step is slightly smaller
-!         than the predicted value  (default=0.9)
+!                  than the predicted value (default = 0.9)
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !
 !
@@ -284,7 +299,7 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
    KPP_REAL :: Roundoff, FacMin, FacMax, FacRej, FacSafe
    KPP_REAL :: Hmin, Hmax, Hstart
    KPP_REAL :: Texit
-   INTEGER       :: i, UplimTol, Max_no_steps
+   INTEGER       :: i, UplimTol, Max_no_steps, ErrNormSpcCount
    LOGICAL       :: Autonomous, VectorTol
 !~~~>   Parameters
    KPP_REAL, PARAMETER :: ZERO = 0.0_dp, ONE  = 1.0_dp
@@ -297,8 +312,8 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
 !~~~>  Autonomous (1) or time dependent ODE (0). Default is time dependent.
    Autonomous = .NOT.(ICNTRL(1) == 0)
 
-!~~~>  For Scalar tolerances (ICNTRL(2).NE.0)  the code uses AbsTol(1) and RelTol(1)
-!   For Vector tolerances (ICNTRL(2) == 0) the code uses AbsTol(1:N) and RelTol(1:N)
+!~~~>  For Scalar tolerances (ICNTRL(2).NE.0), use AbsTol(1) and RelTol(1)
+!~~~>  For Vector tolerances (ICNTRL(2) == 0), use AbsTol(1:N) and RelTol(1:N)
    IF (ICNTRL(2) == 0) THEN
       VectorTol = .TRUE.
       UplimTol  = N
@@ -329,7 +344,7 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
        RETURN
    END SELECT
 
-!~~~>   The maximum number of steps admitted
+!~~~>  The maximum number of steps admitted
    IF (ICNTRL(4) == 0) THEN
       Max_no_steps = 200000
    ELSEIF (ICNTRL(4) > 0) THEN
@@ -339,6 +354,15 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
       CALL ros_ErrorMsg(-1,Tstart,ZERO,IERR)
       RETURN
    END IF
+
+!~~~>  Number of species to use when computing the Rosenbrock error norm
+!~~~>  in function "ros_ErrorNorm".  This allows us to exclude any "dummy"
+!~~~>  species that have been added for diagnostic purposes.
+   IF ( ICNTRL(19) == 0 ) THEN
+      ErrNormSpcCount = N
+   ELSE
+      ErrNormSpcCount = ICNTRL(19)
+   ENDIF
 
 !~~~>  Unit roundoff (1+Roundoff>1)
    Roundoff = EPSILON( 0.0_dp )
@@ -681,31 +705,59 @@ UntilAccepted: DO
                                AbsTol, RelTol, VectorTol )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !~~~> Computes the "scaled norm" of the error vector Yerr
+!~~~>
+!~~~> Now uses separate loops for scalar and vector tolerances,
+!~~~> as this facilitates loop vectorization for better performance.
+!~~~>
+!~~~> Also uses NonPassiveSpc_Count and NonPassiveSpc_Indices (constructed
+!~~~> in Initialize), so that we can exclude "passive" (e.g. prod/loss)
+!~~~> species from the error norm computation.
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    IMPLICIT NONE
 
 ! Input arguments
-   KPP_REAL, INTENT(IN) :: Y(N), Ynew(N), &
-          Yerr(N), AbsTol(N), RelTol(N)
+   KPP_REAL, INTENT(IN) :: Y(N), Ynew(N), Yerr(N), AbsTol(N), RelTol(N)
    LOGICAL, INTENT(IN) ::  VectorTol
 ! Local variables
    KPP_REAL :: Err, Scale, Ymax
-   INTEGER  :: i
-   KPP_REAL, PARAMETER :: ZERO = 0.0_dp
+   INTEGER  :: I, IDX
 
    Err = ZERO
-   DO i=1,N
-     Ymax = MAX(ABS(Y(i)),ABS(Ynew(i)))
-     IF (VectorTol) THEN
-       Scale = AbsTol(i)+RelTol(i)*Ymax
-     ELSE
-       Scale = AbsTol(1)+RelTol(1)*Ymax
-     END IF
-     Err = Err+(Yerr(i)/Scale)**2
-   END DO
-   Err  = SQRT(Err/N)
 
-   ros_ErrorNorm = MAX(Err,1.0d-10)
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   !~~~> Vector Tolerances (per-species AbsTol & RelTol)
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   IF ( VectorTol ) THEN
+
+      DO IDX = 1, NonPassiveSpc_Count
+         I     = NonPassiveSpc_Indices(IDX)
+         Ymax  = MAX( ABS( Y(I) ), ABS( Ynew(I) ) )
+         Scale = AbsTol(I) + RelTol(I) * Ymax
+         Err   = Err + ( Yerr(I) / Scale )**2
+      ENDDO
+
+      ! Normalize the error norm by the number of non-dummy species
+      ! and prevent it from getting smaller than 1e-10
+      Err           = SQRT( Err / NonPassiveSpc_Count )
+      ros_ErrorNorm = MAX( Err, 1.0d-10 )
+      RETURN
+
+   ENDIF
+
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   !~~~> Scalar Tolerance (same AbsTol & RelTol for all species)
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   DO IDX = 1, NonPassiveSpc_Count
+      I     = NonPassiveSpc_Indices(IDX)
+      Ymax  = MAX( ABS( Y(I) ), ABS( Ynew(I) ) )
+      Scale = AbsTol(1) + RelTol(1) * Ymax
+      Err   = Err + ( Yerr(I) / Scale )**2
+   ENDDO
+   
+   ! Normalize the error norm by the number of non-dummy species
+   ! and prevent it from getting smaller than 1e-10
+   Err           = SQRT( Err / NonPassiveSpc_Count )
+   ros_ErrorNorm = MAX( Err, 1.0d-10 )
 
   END FUNCTION ros_ErrorNorm
 

--- a/int/rosenbrock.f90
+++ b/int/rosenbrock.f90
@@ -218,11 +218,6 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
 !        =  0 :    Allow negative concentrations (default)
 !        =  1 :    Aet negative concentrations to zero
 !
-!    ICNTRL(19) -> Specify # of species to use when computing the error norm
-!        =  0 :    Use N species (default)
-!        =  X :    Use N-X species, where X is the number of "dummy" species
-!                  (i.e. species added to reactions for diagnostic purposes).
-!
 !    RCNTRL(1)  -> Hmin, lower bound for the integration step size.
 !                  It is strongly recommended to keep Hmin = ZERO
 !
@@ -354,15 +349,6 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
       CALL ros_ErrorMsg(-1,Tstart,ZERO,IERR)
       RETURN
    END IF
-
-!~~~>  Number of species to use when computing the Rosenbrock error norm
-!~~~>  in function "ros_ErrorNorm".  This allows us to exclude any "dummy"
-!~~~>  species that have been added for diagnostic purposes.
-   IF ( ICNTRL(19) == 0 ) THEN
-      ErrNormSpcCount = N
-   ELSE
-      ErrNormSpcCount = ICNTRL(19)
-   ENDIF
 
 !~~~>  Unit roundoff (1+Roundoff>1)
    Roundoff = EPSILON( 0.0_dp )

--- a/int/rosenbrock_adj.f90
+++ b/int/rosenbrock_adj.f90
@@ -1744,35 +1744,66 @@ Stage: DO istage = 1, ros_S
 
   END SUBROUTINE ros_SimpleCadjInt
 
+
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   KPP_REAL FUNCTION ros_ErrorNorm ( Y, Ynew, Yerr, &
-               AbsTol, RelTol, VectorTol )
+                               AbsTol, RelTol, VectorTol )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !~~~> Computes the "scaled norm" of the error vector Yerr
+!~~~>
+!~~~> Now uses separate loops for scalar and vector tolerances,
+!~~~> as this facilitates loop vectorization for better performance.
+!~~~>
+!~~~> Also uses NonPassiveSpc_Count and NonPassiveSpc_Indices (constructed
+!~~~> in Initialize), so that we can exclude "passive" (e.g. prod/loss)
+!~~~> species from the error norm computation.
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    IMPLICIT NONE
 
 ! Input arguments
-   KPP_REAL, INTENT(IN) :: Y(NVAR), Ynew(NVAR), &
-          Yerr(NVAR), AbsTol(NVAR), RelTol(NVAR)
+   KPP_REAL, INTENT(IN) :: Y(NVAR), Ynew(NVAR), Yerr(NVAR)
+   KPP_REAL, INTENT(IN) :: AbsTol(NVAR), RelTol(NVAR)
    LOGICAL, INTENT(IN) ::  VectorTol
 ! Local variables
    KPP_REAL :: Err, Scale, Ymax
-   INTEGER  :: i
+   INTEGER  :: I, IDX
 
    Err = ZERO
-   DO i=1,NVAR
-     Ymax = MAX(ABS(Y(i)),ABS(Ynew(i)))
-     IF (VectorTol) THEN
-       Scale = AbsTol(i)+RelTol(i)*Ymax
-     ELSE
-       Scale = AbsTol(1)+RelTol(1)*Ymax
-     END IF
-     Err = Err+(Yerr(i)/Scale)**2
-   END DO
-   Err  = SQRT(Err/NVAR)
 
-   ros_ErrorNorm = MAX(Err,1.0d-10)
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   !~~~> Vector Tolerances (per-species AbsTol & RelTol)
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   IF ( VectorTol ) THEN
+
+      DO IDX = 1, NonPassiveSpc_Count
+         I     = NonPassiveSpc_Indices(IDX)
+         Ymax  = MAX( ABS( Y(I) ), ABS( Ynew(I) ) )
+         Scale = AbsTol(I) + RelTol(I) * Ymax
+         Err   = Err + ( Yerr(I) / Scale )**2
+      ENDDO
+
+      ! Normalize the error norm by the number of non-dummy species
+      ! and prevent it from getting smaller than 1e-10
+      Err           = SQRT( Err / NonPassiveSpc_Count )
+      ros_ErrorNorm = MAX( Err, 1.0d-10 )
+      RETURN
+
+   ENDIF
+
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   !~~~> Scalar Tolerance (same AbsTol & RelTol for all species)
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   DO IDX = 1, NonPassiveSpc_Count
+      I     = NonPassiveSpc_Indices(IDX)
+      Ymax  = MAX( ABS( Y(I) ), ABS( Ynew(I) ) )
+      Scale = AbsTol(1) + RelTol(1) * Ymax
+      Err   = Err + ( Yerr(I) / Scale )**2
+   ENDDO
+   
+   ! Normalize the error norm by the number of non-dummy species
+   ! and prevent it from getting smaller than 1e-10
+   Err           = SQRT( Err / NonPassiveSpc_Count )
+   ros_ErrorNorm = MAX( Err, 1.0d-10 )
 
   END FUNCTION ros_ErrorNorm
 

--- a/int/rosenbrock_adj.f90
+++ b/int/rosenbrock_adj.f90
@@ -232,76 +232,84 @@ SUBROUTINE RosenbrockADJ( Y, NADJ, Lambda,             &
 !~~~>     INPUT PARAMETERS:
 !
 !    Note: For input parameters equal to zero the default values of the
-!       corresponding variables are used.
+!          corresponding variables are used.
 !
-!    ICNTRL(1)   = 1: F = F(y)   Independent of T (AUTONOMOUS)
-!              = 0: F = F(t,y) Depends on T (NON-AUTONOMOUS)
+!    ICNTRL(1)  -> Specify time-dependence of the function to be integrated
+!        =  0 :    F = F(t,y) Depends on T (NON-AUTONOMOUS)
+!        =  1 :    F = F(y)   Independent of T (AUTONOMOUS)
 !
-!    ICNTRL(2)   = 0: AbsTol, RelTol are NVAR-dimensional vectors
-!              = 1:  AbsTol, RelTol are scalars
+!    ICNTRL(2)  -> Specify vector or scalar tolerances
+!        =  0 :    AbsTol, RelTol are N-dimensional vectors
+!        =  1 :    AbsTol, RelTol are scalars
 !
-!    ICNTRL(3)  -> selection of a particular Rosenbrock method
-!        = 0 :  default method is Rodas3
-!        = 1 :  method is  Ros2
-!        = 2 :  method is  Ros3
-!        = 3 :  method is  Ros4
-!        = 4 :  method is  Rodas3
-!        = 5 :  method is  Rodas4
-!        = 7 :  method is  Rodas3.1
+!    ICNTRL(3)  -> Select a particular Rosenbrock method
+!        =  0 :    Rodas3 (default)
+!        =  1 :    Ros2
+!        =  2 :    Ros3
+!        =  3 :    Ros4
+!        =  4 :    Rodas3
+!        =  5 :    Rodas4
+!        =  6 :    Rang3
+!        =  7 :    Rodas3.1
 !
-!    ICNTRL(4)  -> maximum number of integration steps
-!        For ICNTRL(4)=0) the default value of BUFSIZE is used
+!    ICNTRL(4)  -> Specify maximum number of integration steps
+!        =  0 :    Use up to BUFSIZE integration steps (default=200000)
+!        =  X :    Use up to X integration steps (X = any integer)
 !
-!    ICNTRL(6)  -> selection of a particular Rosenbrock method for the
-!                continuous adjoint integration - for cts adjoint it
-!                can be different than the forward method ICNTRL(3)
-!         Note 1: to avoid interpolation errors (which can be huge!)
-!                   it is recommended to use only ICNTRL(7) = 2 or 4
-!         Note 2: the performance of the full continuous adjoint
-!                   strongly depends on the forward solution accuracy Abs/RelTol
+!    ICNTRL(6)  -> Selection of a particular Rosenbrock method for the continuous 
+!                  adjoint integration; this may be different than the forward
+!                  method specified in ICNTRL(3).
 !
-!    ICNTRL(7) -> Type of adjoint algorithm
-!         = 0 : default is discrete adjoint ( of method ICNTRL(3) )
-!         = 1 : no adjoint
-!         = 2 : discrete adjoint ( of method ICNTRL(3) )
-!         = 3 : fully adaptive continuous adjoint ( with method ICNTRL(6) )
-!         = 4 : simplified continuous adjoint ( with method ICNTRL(6) )
+!                  Note 1: to avoid interpolation errors (which can be huge!)
+!                  it is recommended to use only ICNTRL(7) = 2 or 4
 !
-!    ICNTRL(8)  -> checkpointing the LU factorization at each step:
-!        ICNTRL(8)=0 : do *not* save LU factorization (the default)
-!        ICNTRL(8)=1 : save LU factorization
-!        Note: if ICNTRL(7)=1 the LU factorization is *not* saved
+!                  Note 2: the performance of the full continuous adjoint
+!                  strongly depends on the forward solution accuracy Abs/RelTol
 !
-!    ICNTRL(15) -> Toggles calling of Update_* functions w/in the integrator
-!        = -1 : Do not call Update_* functions within the integrator
-!        =  0 : Status quo
-!        =  1 : Call Update_RCONST from within the integrator
-!        =  2 : Call Update_PHOTO from within the integrator
-!        =  3 : Call Update_RCONST and Update_PHOTO from w/in the int.
-!        =  4 : Call Update_SUN from within the integrator
-!        =  5 : Call Update_SUN and Update_RCONST from within the int.
-!        =  6 : Call Update_SUN and Update_PHOTO from within the int.
-!        =  7 : Call Update_SUN, Update_PHOTO, Update_RCONST w/in the int.
+!    ICNTRL(7)  -> Type of adjoint algorithm
+!        =  0 :    default is discrete adjoint ( of method ICNTRL(3) )
+!        =  1 :    no adjoint
+!        =  2 :    discrete adjoint ( of method ICNTRL(3) )
+!        =  3 :    fully adaptive continuous adjoint ( with method ICNTRL(6) )
+!        =  4 :    simplified continuous adjoint ( with method ICNTRL(6) )
+!
+!    ICNTRL(8)  -> Checkpoint the LU factorization at each step?
+!        =  0 :    Do *not* save LU factorization (the default)
+!        =  1 :    Save LU factorization at each step
+!
+!                  Note: if ICNTRL(7)=1 the LU factorization is *not* saved
+!
+!    ICNTRL(15) -> Toggle calling of Update_* functions w/in the integrator
+!        = -1 :    Do not call Update_* functions within the integrator
+!        =  0 :    Status quo
+!        =  1 :    Call Update_RCONST from within the integrator
+!        =  2 :    Call Update_PHOTO from within the integrator
+!        =  3 :    Call Update_RCONST and Update_PHOTO from w/in the int.
+!        =  4 :    Call Update_SUN from within the integrator
+!        =  5 :    Call Update_SUN and Update_RCONST from within the int.
+!        =  6 :    Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :    Call Update_SUN, Update_PHOTO, Update_RCONST w/in the int.
 !
 !~~~>  Real input parameters:
 !
-!    RCNTRL(1)  -> Hmin, lower bound for the integration step size
-!          It is strongly recommended to keep Hmin = ZERO
+!    RCNTRL(1)  -> Hmin, lower bound for the integration step size.
+!                  It is strongly recommended to keep Hmin = ZERO
 !
 !    RCNTRL(2)  -> Hmax, upper bound for the integration step size
 !
 !    RCNTRL(3)  -> Hstart, starting value for the integration step size
 !
-!    RCNTRL(4)  -> FacMin, lower bound on step decrease factor (default=0.2)
+!    RCNTRL(4)  -> FacMin, lower bound on step decrease factor 
+!                  (default = 0.2)
 !
-!    RCNTRL(5)  -> FacMax, upper bound on step increase factor (default=6)
+!    RCNTRL(5)  -> FacMax, upper bound on step increase factor
+!                  (default = 6)
 !
 !    RCNTRL(6)  -> FacRej, step decrease factor after multiple rejections
-!            (default=0.1)
+!                  (default = 0.1)
 !
 !    RCNTRL(7)  -> FacSafe, by which the new step is slightly smaller
-!         than the predicted value  (default=0.9)
-!
+!                  than the predicted value (default = 0.9)
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !
 !~~~>     OUTPUT PARAMETERS:

--- a/int/rosenbrock_autoreduce.f90
+++ b/int/rosenbrock_autoreduce.f90
@@ -1674,36 +1674,65 @@ Stage: DO istage = 1, ros_S
    Y = term+(Y-term)*exp(-k*(Tf-Ti))
  END SUBROUTINE AutoReduce_1stOrder
 
+
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   KPP_REAL FUNCTION ros_ErrorNorm ( Y, Ynew, Yerr, &
                                AbsTol, RelTol, VectorTol )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !~~~> Computes the "scaled norm" of the error vector Yerr
+!~~~>
+!~~~> Now uses separate loops for scalar and vector tolerances,
+!~~~> as this facilitates loop vectorization for better performance.
+!~~~>
+!~~~> Also uses NonPassiveSpc_Count and NonPassiveSpc_Indices (constructed
+!~~~> in Initialize), so that we can exclude "passive" (e.g. prod/loss)
+!~~~> species from the error norm computation.
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    IMPLICIT NONE
 
 ! Input arguments
-   KPP_REAL, INTENT(IN) :: Y(N), Ynew(N), &
-          Yerr(N), AbsTol(N), RelTol(N)
+   KPP_REAL, INTENT(IN) :: Y(N), Ynew(N), Yerr(N), AbsTol(N), RelTol(N)
    LOGICAL, INTENT(IN) ::  VectorTol
 ! Local variables
    KPP_REAL :: Err, Scale, Ymax
-   INTEGER  :: i
-   KPP_REAL, PARAMETER :: ZERO = 0.0_dp
+   INTEGER  :: I, IDX
 
    Err = ZERO
-   DO i=1,N
-     Ymax = MAX(ABS(Y(i)),ABS(Ynew(i)))
-     IF (VectorTol) THEN
-       Scale = AbsTol(i)+RelTol(i)*Ymax
-     ELSE
-       Scale = AbsTol(1)+RelTol(1)*Ymax
-     END IF
-     Err = Err+(Yerr(i)/Scale)**2
-   END DO
-   Err  = SQRT(Err/N)
 
-   ros_ErrorNorm = MAX(Err,1.0d-10)
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   !~~~> Vector Tolerances (per-species AbsTol & RelTol)
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   IF ( VectorTol ) THEN
+
+      DO IDX = 1, NonPassiveSpc_Count
+         I     = NonPassiveSpc_Indices(IDX)
+         Ymax  = MAX( ABS( Y(I) ), ABS( Ynew(I) ) )
+         Scale = AbsTol(I) + RelTol(I) * Ymax
+         Err   = Err + ( Yerr(I) / Scale )**2
+      ENDDO
+
+      ! Normalize the error norm by the number of non-dummy species
+      ! and prevent it from getting smaller than 1e-10
+      Err           = SQRT( Err / NonPassiveSpc_Count )
+      ros_ErrorNorm = MAX( Err, 1.0d-10 )
+      RETURN
+
+   ENDIF
+
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   !~~~> Scalar Tolerance (same AbsTol & RelTol for all species)
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   DO IDX = 1, NonPassiveSpc_Count
+      I     = NonPassiveSpc_Indices(IDX)
+      Ymax  = MAX( ABS( Y(I) ), ABS( Ynew(I) ) )
+      Scale = AbsTol(1) + RelTol(1) * Ymax
+      Err   = Err + ( Yerr(I) / Scale )**2
+   ENDDO
+   
+   ! Normalize the error norm by the number of non-dummy species
+   ! and prevent it from getting smaller than 1e-10
+   Err           = SQRT( Err / NonPassiveSpc_Count )
+   ros_ErrorNorm = MAX( Err, 1.0d-10 )
 
   END FUNCTION ros_ErrorNorm
 

--- a/int/rosenbrock_autoreduce.f90
+++ b/int/rosenbrock_autoreduce.f90
@@ -184,60 +184,78 @@ SUBROUTINE Rosenbrock(N,Y,Tstart,Tend, &
 !~~~>     INPUT PARAMETERS:
 !
 !    Note: For input parameters equal to zero the default values of the
-!       corresponding variables are used.
+!          corresponding variables are used.
 !
-!    ICNTRL(1) = 1: F = F(y)   Independent of T (AUTONOMOUS)
-!              = 0: F = F(t,y) Depends on T (NON-AUTONOMOUS)
+!    ICNTRL(1)  -> Specify time-dependence of the function to be integrated
+!        =  0 :    F = F(t,y) Depends on T (NON-AUTONOMOUS)
+!        =  1 :    F = F(y)   Independent of T (AUTONOMOUS)
 !
-!    ICNTRL(2) = 0: AbsTol, RelTol are N-dimensional vectors
-!              = 1: AbsTol, RelTol are scalars
+!    ICNTRL(2)  -> Specify vector or scalar tolerances
+!        =  0 :    AbsTol, RelTol are N-dimensional vectors
+!        =  1 :    AbsTol, RelTol are scalars
 !
-!    ICNTRL(3)  -> selection of a particular Rosenbrock method
-!        = 0 :    Rodas3 (default)
-!        = 1 :    Ros2
-!        = 2 :    Ros3
-!        = 3 :    Ros4
-!        = 4 :    Rodas3
-!        = 5 :    Rodas4
-!        = 6 :    Rang3
-!        = 7 :    Rodas3.1
+!    ICNTRL(3)  -> Select a particular Rosenbrock method
+!        =  0 :    Rodas3 (default)
+!        =  1 :    Ros2
+!        =  2 :    Ros3
+!        =  3 :    Ros4
+!        =  4 :    Rodas3
+!        =  5 :    Rodas4
+!        =  6 :    Rang3
+!        =  7 :    Rodas3.1
 !
-!    ICNTRL(4)  -> maximum number of integration steps
-!        For ICNTRL(4)=0) the default value of 200000 is used
+!    ICNTRL(4)  -> Specify maximum number of integration steps
+!        =  0 :    Use up to 20000 integration steps (default)
+!        =  X :    Use up to X integration steps (X = any integer)!
 !
-!    ICNTRL(12)  -> use auto-reduce solver? set threshold in RCNTRL(12)
-!    ICNTRL(13)  -> ... append slow species when auto-reducing?
+!    ICNTRL(12) -> Use auto-reduce solver?
+!        =  0 :    Do not use the auto-reduction solver
+!        =  1 :    Use the auto reduction solver.  Set the threshold in RCNTRL(12)
+!                     
+!    ICNTRL(13) -> Append slow species when auto-reducing?
+!        =  0 :    Do not append slow species
+!        =  1 :    Append slow species
+!
 !    ICNTRL(14) -> choose a target species instead for determining threshold?
 !                  if yes, specify idx. then RCNTRL(12) is obsolete.
 !
-!    ICNTRL(15) -> Toggles calling of Update_* functions w/in the integrator
-!        = -1 :  Do not call Update_* functions within the integrator
-!        =  0 :  Status quo
-!        =  1 :  Call Update_RCONST from within the integrator
-!        =  2 :  Call Update_PHOTO from within the integrator
-!        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
-!        =  4 :  Call Update_SUN from within the integrator
-!        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
-!        =  7 :  Call Update_SUN, Update_PHOTO, Update_RCONST w/in the int.
+!    ICNTRL(15) -> Toggle calling of Update_* functions w/in the integrator
+!        = -1 :    Do not call Update_* functions within the integrator
+!        =  0 :    Status quo
+!        =  1 :    Call Update_RCONST from within the integrator
+!        =  2 :    Call Update_PHOTO from within the integrator
+!        =  3 :    Call Update_RCONST and Update_PHOTO from w/in the int.
+!        =  4 :    Call Update_SUN from within the integrator
+!        =  5 :    Call Update_SUN and Update_RCONST from within the int.
+!        =  6 :    Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :    Call Update_SUN, Update_PHOTO, Update_RCONST w/in the int.
 !
-!    ICNTRL(16) ->
-!        = 0 : allow negative concentrations (default)
-!        = 1 : set negative concentrations to zero
+!    ICNTRL(16) -> Specify how negative concentrations are handled
+!        =  0 :    Allow negative concentrations (default)
+!        =  1 :    Aet negative concentrations to zero
 !
-!    RCNTRL(1)  -> Hmin, lower bound for the integration step size
-!          It is strongly recommended to keep Hmin = ZERO
+!    RCNTRL(1)  -> Hmin, lower bound for the integration step size.
+!                  It is strongly recommended to keep Hmin = ZERO
+!
 !    RCNTRL(2)  -> Hmax, upper bound for the integration step size
+!
 !    RCNTRL(3)  -> Hstart, starting value for the integration step size
 !
-!    RCNTRL(4)  -> FacMin, lower bound on step decrease factor (default=0.2)
-!    RCNTRL(5)  -> FacMax, upper bound on step increase factor (default=6)
-!    RCNTRL(6)  -> FacRej, step decrease factor after multiple rejections
-!                          (default=0.1)
-!    RCNTRL(7)  -> FacSafe, by which the new step is slightly smaller
-!         than the predicted value  (default=0.9)
+!    RCNTRL(4)  -> FacMin, lower bound on step decrease factor 
+!                  (default = 0.2)
 !
-!    RCNTRL(12) -> threshold for auto-reduction (req. ICNTRL(12)) (default=100)
+!    RCNTRL(5)  -> FacMax, upper bound on step increase factor
+!                  (default = 6)
+!
+!    RCNTRL(6)  -> FacRej, step decrease factor after multiple rejections
+!                  (default = 0.1)
+!
+!    RCNTRL(7)  -> FacSafe, by which the new step is slightly smaller
+!                  than the predicted value (default = 0.9)
+!
+!    RCNTRL(12) -> Threshold for auto-reduction, when ICNTRL(12) is set 
+!                  (default=100)
+!
 !    RCNTRL(14) -> AR threshold ratio (default=0.01)
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !

--- a/int/rosenbrock_tlm.f90
+++ b/int/rosenbrock_tlm.f90
@@ -764,36 +764,65 @@ Stage: DO istage = 1, ros_S
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   KPP_REAL FUNCTION ros_ErrorNorm ( Y, Ynew, Yerr, &
-               AbsTol, RelTol, VectorTol )
+                               AbsTol, RelTol, VectorTol )
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !~~~> Computes the "scaled norm" of the error vector Yerr
+!~~~>
+!~~~> Now uses separate loops for scalar and vector tolerances,
+!~~~> as this facilitates loop vectorization for better performance.
+!~~~>
+!~~~> Also uses NonPassiveSpc_Count and NonPassiveSpc_Indices (constructed
+!~~~> in Initialize), so that we can exclude "passive" (e.g. prod/loss)
+!~~~> species from the error norm computation.
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    IMPLICIT NONE
 
 ! Input arguments
-   KPP_REAL, INTENT(IN) :: Y(N), Ynew(N),    &
-          Yerr(N), AbsTol(N), RelTol(N)
+   KPP_REAL, INTENT(IN) :: Y(N), Ynew(N), Yerr(N), AbsTol(N), RelTol(N)
    LOGICAL, INTENT(IN) ::  VectorTol
 ! Local variables
    KPP_REAL :: Err, Scale, Ymax
-   INTEGER  :: i
-   KPP_REAL, PARAMETER :: ZERO = 0.0d0
+   INTEGER  :: I, IDX
 
    Err = ZERO
-   DO i=1,N
-     Ymax = MAX(ABS(Y(i)),ABS(Ynew(i)))
-     IF (VectorTol) THEN
-       Scale = AbsTol(i)+RelTol(i)*Ymax
-     ELSE
-       Scale = AbsTol(1)+RelTol(1)*Ymax
-     END IF
-     Err = Err+(Yerr(i)/Scale)**2
-   END DO
-   Err  = SQRT(Err/N)
 
-   ros_ErrorNorm = MAX(Err,1.0d-10)
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   !~~~> Vector Tolerances (per-species AbsTol & RelTol)
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   IF ( VectorTol ) THEN
+
+      DO IDX = 1, NonPassiveSpc_Count
+         I     = NonPassiveSpc_Indices(IDX)
+         Ymax  = MAX( ABS( Y(I) ), ABS( Ynew(I) ) )
+         Scale = AbsTol(I) + RelTol(I) * Ymax
+         Err   = Err + ( Yerr(I) / Scale )**2
+      ENDDO
+
+      ! Normalize the error norm by the number of non-dummy species
+      ! and prevent it from getting smaller than 1e-10
+      Err           = SQRT( Err / NonPassiveSpc_Count )
+      ros_ErrorNorm = MAX( Err, 1.0d-10 )
+      RETURN
+
+   ENDIF
+
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   !~~~> Scalar Tolerance (same AbsTol & RelTol for all species)
+   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   DO IDX = 1, NonPassiveSpc_Count
+      I     = NonPassiveSpc_Indices(IDX)
+      Ymax  = MAX( ABS( Y(I) ), ABS( Ynew(I) ) )
+      Scale = AbsTol(1) + RelTol(1) * Ymax
+      Err   = Err + ( Yerr(I) / Scale )**2
+   ENDDO
+   
+   ! Normalize the error norm by the number of non-dummy species
+   ! and prevent it from getting smaller than 1e-10
+   Err           = SQRT( Err / NonPassiveSpc_Count )
+   ros_ErrorNorm = MAX( Err, 1.0d-10 )
 
   END FUNCTION ros_ErrorNorm
+
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   KPP_REAL FUNCTION ros_ErrorNorm_tlm ( Y_tlm, Ynew_tlm, Yerr_tlm, &

--- a/int/rosenbrock_tlm.f90
+++ b/int/rosenbrock_tlm.f90
@@ -219,52 +219,63 @@ SUBROUTINE RosenbrockTLM(N,Y,NTLM,Y_tlm,                      &
 !~~~>     INPUT PARAMETERS:
 !
 !    Note: For input parameters equal to zero the default values of the
-!       corresponding variables are used.
+!          corresponding variables are used.
 !
-!    ICNTRL(1)   = 1: F = F(y)   Independent of T (AUTONOMOUS)
-!              = 0: F = F(t,y) Depends on T (NON-AUTONOMOUS)
+!    ICNTRL(1)  -> Specify time-dependence of the function to be integrated
+!        =  0 :    F = F(t,y) Depends on T (NON-AUTONOMOUS)
+!        =  1 :    F = F(y)   Independent of T (AUTONOMOUS)
 !
-!    ICNTRL(2)   = 0: AbsTol, RelTol are N-dimensional vectors
-!              = 1:  AbsTol, RelTol are scalars
+!    ICNTRL(2)  -> Specify vector or scalar tolerances
+!        =  0 :    AbsTol, RelTol are N-dimensional vectors
+!        =  1 :    AbsTol, RelTol are scalars
 !
-!    ICNTRL(3)  -> selection of a particular Rosenbrock method
-!        = 0 :  default method is Rodas3
-!        = 1 :  method is  Ros2
-!        = 2 :  method is  Ros3
-!        = 3 :  method is  Ros4
-!        = 4 :  method is  Rodas3
-!        = 5 :  method is  Rodas4
-!        = 7 :  method is  Rodas3.1
+!    ICNTRL(3)  -> Select a particular Rosenbrock method
+!        =  0 :    Rodas3 (default)
+!        =  1 :    Ros2
+!        =  2 :    Ros3
+!        =  3 :    Ros4
+!        =  4 :    Rodas3
+!        =  5 :    Rodas4
+!        =  6 :    Rang3
+!        =  7 :    Rodas3.1
 !
-!    ICNTRL(4)  -> maximum number of integration steps
-!        For ICNTRL(4)=0) the default value of 200000 is used
+!    ICNTRL(4)  -> Specify maximum number of integration steps
+!        =  0 :    Use up to 20000 integration steps (default)
+!        =  X :    Use up to X integration steps (X = any integer)
 !
-!    ICNTRL(12) -> switch for TLM truncation error control
-!        ICNTRL(12) = 0: TLM error is not used
-!        ICNTRL(12) = 1: TLM error is computed and used
+!    ICNTRL(12) -> Switch for TLM truncation error control
+!        =  0 :    TLM error is not used
+!        =  1 :    TLM error is computed and used
 !
-!    ICNTRL(15) -> Toggles calling of Update_* functions w/in the integrator
-!        = -1 :  Do not call Update_* functions within the integrator
-!        =  0 :  Status quo
-!        =  1 :  Call Update_RCONST from within the integrator
-!        =  2 :  Call Update_PHOTO from within the integrator
-!        =  3 :  Call Update_RCONST and Update_PHOTO from w/in the int.
-!        =  4 :  Call Update_SUN from within the integrator
-!        =  5 :  Call Update_SUN and Update_RCONST from within the int.
-!        =  6 :  Call Update_SUN and Update_PHOTO from within the int.
-!        =  7 :  Call Update_SUN, Update_PHOTO, Update_RCONST w/in the int.
+!    ICNTRL(15) -> Toggle calling of Update_* functions w/in the integrator
+!        = -1 :    Do not call Update_* functions within the integrator
+!        =  0 :    Status quo
+!        =  1 :    Call Update_RCONST from within the integrator
+!        =  2 :    Call Update_PHOTO from within the integrator
+!        =  3 :    Call Update_RCONST and Update_PHOTO from w/in the int.
+!        =  4 :    Call Update_SUN from within the integrator
+!        =  5 :    Call Update_SUN and Update_RCONST from within the int.
+!        =  6 :    Call Update_SUN and Update_PHOTO from within the int.
+!        =  7 :    Call Update_SUN, Update_PHOTO, Update_RCONST w/in the int.
 
-!    RCNTRL(1)  -> Hmin, lower bound for the integration step size
-!          It is strongly recommended to keep Hmin = ZERO
+!    RCNTRL(1)  -> Hmin, lower bound for the integration step size.
+!                  It is strongly recommended to keep Hmin = ZERO
+!
 !    RCNTRL(2)  -> Hmax, upper bound for the integration step size
+!
 !    RCNTRL(3)  -> Hstart, starting value for the integration step size
 !
-!    RCNTRL(4)  -> FacMin, lower bound on step decrease factor (default=0.2)
-!    RCNTRL(5)  -> FacMin,upper bound on step increase factor (default=6)
+!    RCNTRL(4)  -> FacMin, lower bound on step decrease factor 
+!                  (default = 0.2)
+!
+!    RCNTRL(5)  -> FacMax, upper bound on step increase factor
+!                  (default = 6)
+!
 !    RCNTRL(6)  -> FacRej, step decrease factor after multiple rejections
-!                       (default=0.1)
+!                  (default = 0.1)
+!
 !    RCNTRL(7)  -> FacSafe, by which the new step is slightly smaller
-!         than the predicted value  (default=0.9)
+!                  than the predicted value  (default=0.9)
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !
 !~~~>     OUTPUT PARAMETERS:

--- a/int/runge_kutta.c
+++ b/int/runge_kutta.c
@@ -673,6 +673,11 @@ void RK_Integrator( int N,
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
+   // Initialize variables to avoid compiler warnings
+   //   -- Bob Yantosca (06 Jul 2026)
+   Hacc = ZERO;
+   ErrOld = ZERO;
+
   /*~~~>  INITIAL setting */
    Tdirection = SIGN(ONE, Tend-*T);
    H = MIN( MAX(ABS(Hmin), ABS(Hstart)), Hmax );

--- a/src/code.c
+++ b/src/code.c
@@ -52,6 +52,7 @@ void (*DeclareConstant)( int v, char *val );
 void (*FunctionStart)( int f, int *vars );
 void (*FunctionPrototipe)( int f, ... );
 void (*FunctionBegin)( int f, ... );
+void (*FunctionBeginNoArgDecl)( int f, ... );
 void (*FunctionEnd)( int f );
 
 // Local definitions of function prototypes just for code.c

--- a/src/code.h
+++ b/src/code.h
@@ -133,6 +133,7 @@ void FreeVariable( int n );
 
 #define DefConst( name, bt, cmt ) DefineVariable( name, CONST, bt, 0, 0, cmt, 0 )
 #define DefElm( name, bt, cmt ) DefineVariable( name, ELM, bt, 0, 0, cmt, 0 )
+#define DefElmO( name, bt, cmt ) DefineVariable( name, ELM, bt, 0, 0, cmt, ATTR_F90_OPT )
 #define DefvElm( name, bt, n, cmt ) DefineVariable( name, VELM, bt, n, 0, cmt, 0 )
 #define DefmElm( name, bt, m, n, cmt ) DefineVariable( name, MELM, bt, m, n, cmt, 0)
 #define DefeElm( name, cmt ) DefineVariable( name, EELM, 0, 0, 0, cmt, 0 )
@@ -208,6 +209,7 @@ extern void (*DeclareConstant)( int v, char *val );
 extern void (*FunctionStart)( int f, int *vars );
 extern void (*FunctionPrototipe)( int f, ... );
 extern void (*FunctionBegin)( int f, ... );
+extern void (*FunctionBeginNoArgDecl)( int f, ... );
 extern void (*FunctionEnd)( int f );
 
 void WriteDelim();

--- a/src/code_c.c
+++ b/src/code_c.c
@@ -531,6 +531,9 @@ void Use_C( char* rootFileName )
   FunctionBegin     = C_FunctionBegin;
   FunctionEnd       = C_FunctionEnd;
 
+  // FunctionBeginNoArgDecl is only defined for Fortran-90
+  FunctionBeginNoArgDecl = NULL;
+
   OpenFile( &param_headerFile,   rootFileName, "_Parameters.h", "Parameter Header File" );
   OpenFile( &initFile, rootFileName, "_Initialize.c", "Initialization File" );
   OpenFile( &driverFile, rootFileName, "_Main.c", "Main Program File" );

--- a/src/code_f77.c
+++ b/src/code_f77.c
@@ -554,6 +554,9 @@ void Use_F( char* rootFileName )
   FunctionBegin     = F77_FunctionBegin;
   FunctionEnd       = F77_FunctionEnd;
 
+  // FunctionBeginNoArgDecl is only defined for Fortran-90
+  FunctionBeginNoArgDecl = NULL;
+
   OpenFile( &param_headerFile,   rootFileName, "_Parameters.h", "Parameter Header File" );
   OpenFile( &initFile, rootFileName, "_Initialize.f", "Initialization File" );
   OpenFile( &driverFile, rootFileName, "_Main.f", "Main Program File" );

--- a/src/code_f90.c
+++ b/src/code_f90.c
@@ -241,8 +241,16 @@ char maxj[20];
   *buf = 0;
 
   switch( var->type ) {
-    case ELM:
-                sprintf( buf, "%s :: %s", baseType, var->name );
+    case ELM:   //
+                // Modify the IF block so that F90 scalar variables
+                // can be declared with the OPTIONAL attribute.
+                //  -- Bob Yantosca (02 Jul 2026)
+                //
+                if ( var->attr == ATTR_F90_OPT ) {
+		  sprintf( buf, "%s, OPTIONAL :: %s", baseType, var->name );
+                } else {
+                  sprintf( buf, "%s :: %s", baseType, var->name );
+                }
 		break;
     case VELM:
                 if( var->maxi > 0 ) sprintf( maxi, "%d", var->maxi );
@@ -257,12 +265,12 @@ char maxj[20];
 		      sprintf( maxi, "%d", (varTable[-var->maxi]->value)==0?
 		           1:varTable[-var->maxi]->value );
 		}
-
-		//=============================================================
+		//
 		// MODIFICATION by Bob Yantosca (28 Apr 2022)
 		//
 		// Modify the IF block so that F90 variables can be declared
 		// with either the POINTER, TARGET, or OPTIONAL attribute.
+		//  -- Bob Yantosca (28 Apr 2022)
 		//
 		if ( var->attr == ATTR_F90_PTR )
 		  sprintf( buf, "%s, POINTER :: %s(:)", baseType,
@@ -281,7 +289,6 @@ char maxj[20];
 			                                           maxi );
 		else
 		  sprintf( buf, "%s :: %s(%s)", baseType, var->name, maxi );
-		//=============================================================
  		break;
 
     case MELM:
@@ -383,10 +390,9 @@ int maxCols = MAX_COLS;
           strcat( maxi, "+1");
 	bprintf( "  %s, " , baseType);
         if( n>0 ) bprintf( "PARAMETER, " ); /* if values are assigned now */
-	//====================================================================
-	// MODIFICATION by Bob Yantosca (28 Apr 2022)
 	//
 	// Add the POINTER, TARGET, or OPTIONAL attributes to F90 variables.
+	//   - Bob Yantosca (28 Apr 2022)
 	//
 	if ( var->attr == ATTR_F90_PTR ) {
           bprintf( ", POINTER :: %s(:)", var->name ) ;
@@ -404,7 +410,7 @@ int maxCols = MAX_COLS;
           bprintf( ", OPTIONAL, POINTER :: %s(%s)", var->name, maxi ) ;
 	  if( n<=0 ) break;
         }
-	//====================================================================
+	//
         if ( maxi_div==0 ) { /* define array in one piece */
           bprintf( "DIMENSION(%s) :: %s",
                    maxi, var->name) ;
@@ -723,6 +729,38 @@ int narg;
 }
 
 /*************************************************************************************************/
+void F90_FunctionBeginNoArgDecl( int f, ... )
+{
+//
+// FunctionBeginNoArgDecl is similar to FunctionBegin, except that function
+// arguments are not declared.  This allows the user to manually declare
+// F90 function arguments lower down in the code, following any F90 USE
+// statements.  This will help to avoid compilation errors.
+//   -- Bob Yantosca (02 Jul 2026)
+//
+Va_list args;
+int i;
+int vars[20];
+int narg;
+
+  narg = varTable[ f ]->maxi;
+
+  Va_start( args, f );
+  for( i = 0; i < narg; i++ )
+    vars[ i ] = va_arg( args, int );
+  va_end( args );
+
+  CommentFncBegin( f, vars );
+  F90_FunctionStart( f, vars );
+  NewLines(1);
+
+  bprintf("\n");
+  FlushBuf();
+
+  LogFunctionComment( f, vars );
+}
+
+/*************************************************************************************************/
 void F90_FunctionEnd( int f )
 {
   bprintf("      \nEND SUBROUTINE %s\n\n", varTable[ f ]->name );
@@ -769,6 +807,7 @@ void Use_F90( char* rootFileName )
   FunctionStart         = F90_FunctionStart;
   FunctionPrototipe     = F90_FunctionPrototipe;
   FunctionBegin         = F90_FunctionBegin;
+  FunctionBeginNoArgDecl= F90_FunctionBeginNoArgDecl;
   FunctionEnd           = F90_FunctionEnd;
 
   // Parameters

--- a/src/code_matlab.c
+++ b/src/code_matlab.c
@@ -677,6 +677,9 @@ void Use_MATLAB( char *rootFileName )
   FunctionBegin     = MATLAB_FunctionBegin;
   FunctionEnd       = MATLAB_FunctionEnd;
 
+  // FunctionBeginNoArgDecl is only defined for Fortran-90
+  FunctionBeginNoArgDecl = NULL;
+
   OpenFile( &param_headerFile,   rootFileName, "_Parameters.m","Parameter Definition File" );
   OpenFile( &driverFile, rootFileName, "_Main.m", "Main Program File" );
   OpenFile( &rateFile, rootFileName, "_Rates.m", 

--- a/src/gen.c
+++ b/src/gen.c
@@ -75,7 +75,6 @@ int ATOL, RTOL, STEPMIN, STEPMAX, CFACTOR;
 int V_USER, CL;
 int NMLCV, NMLCF, SCT, PROPENSITY, VOLUME, IRCT;
 int FAM,NFAM;
-int NON_PASV_SPC_CT, NON_PASV_SPC_IND;
 
 int Jac_NZ, LU_Jac_NZ, nzr;
 
@@ -279,20 +278,6 @@ int i,j;
   FAM_NAMES  = DefvElm( "FAM_NAMES", STRING, -NFAM, "Names of chemical familes" );
 
   CFACTOR  = DefElm( "CFACTOR", real, "Conversion factor for concentration units");
-  //
-  // Define variables that will allow us to exclude "passive" species (those
-  // added to reactions for diagnostic purposes), for Fortran90 only.
-  //   -- Bob Yantosca (02 Jul 2026)
-  //
-  if ( useLang == F90_LANG ) {
-    NON_PASV_SPC_CT = DefElm( "NonPassiveSpc_Count", INT,
-			      "Number of non-passive species in mechanism" );
-    NON_PASV_SPC_IND = DefvElm( "NonPassiveSpc_Indices", INT, -NVAR,
-				"Indices of non-passive species in mechanism" );
-  } else {
-    NON_PASV_SPC_CT = 0;
-    NON_PASV_SPC_IND = 0;
-  }
   //
   // Autoreduction structures
   //
@@ -2363,7 +2348,7 @@ int YIN, Y;
 
   UseFile( rateFile );
 
-  if (useLang==F90_LANG) {
+  if ( useLang==F90_LANG ) {
     //
     // SPECIAL HANDLING FOR FORTRAN-90
     // -------------------------------
@@ -2418,6 +2403,8 @@ int YIN, Y;
     UPDATE_RCONST = DefFnc( "Update_RCONST", 0,
 			    "function to update rate constants");
     FunctionBegin( UPDATE_RCONST );
+    YIN = 0;
+    Y = 0;
   }
   //
   // Inline F77 and MATLAB include files
@@ -2477,7 +2464,10 @@ int YIN, Y;
   //
   FunctionEnd( UPDATE_RCONST );
   FreeVariable( UPDATE_RCONST );
-  FreeVariable( YIN );
+  if ( useLang == F90_LANG ) {
+    FreeVariable( YIN );
+    FreeVariable( Y );
+  }
 }
 
 
@@ -2732,7 +2722,6 @@ int j,dummy_species;
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 void GenerateGlobalHeader()
 {
-  int useFortran;
   //
   // Modify code to inline the F77/F90 THREADPRIVATE declarations, and also
   // declare extra arrays and scalars.  These declarations begin with a
@@ -2742,9 +2731,27 @@ void GenerateGlobalHeader()
   //
   // Define a flag to denote if we are using Fortran (either F90 or F77)
   //
+  int useFortran;
   if ( useLang == F90_LANG || useLang == F77_LANG ) { useFortran = 1; }
   else                                              { useFortran = 0; }
-
+  //
+  // Define variables that will allow us to exclude "passive" species (those
+  // added to reactions for diagnostic purposes), for Fortran90 only.
+  //   -- Bob Yantosca (02 Jul 2026)
+  //
+  int NON_PASV_SPC_CT, NON_PASV_SPC_IND;
+  if ( useLang == F90_LANG ) {
+    NON_PASV_SPC_CT = DefElm( "NonPassiveSpc_Count", INT,
+			      "Number of non-passive species in mechanism" );
+    NON_PASV_SPC_IND = DefvElm( "NonPassiveSpc_Indices", INT, -NVAR,
+				"Indices of non-passive species in mechanism" );
+  } else {
+    NON_PASV_SPC_CT = 0;
+    NON_PASV_SPC_IND = 0;
+  }
+  //
+  // Initialize
+  //
   UseFile( global_dataFile );
 
   CommonName = "GDATA";
@@ -2942,6 +2949,10 @@ void GenerateGlobalHeader()
   NewLines(1);
   WriteComment("End inlined code from F90_GLOBAL");
   NewLines(1);
+  if ( useLang == F90_LANG ) {
+    FreeVariable( NON_PASV_SPC_CT );
+    FreeVariable( NON_PASV_SPC_IND );
+  }
 }
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/

--- a/src/gen.c
+++ b/src/gen.c
@@ -3274,7 +3274,7 @@ int INITVAL, PASV_SPC_ATOL_THRESH;
     // C, FORTRAN-77, MATLAB
     // ---------------------
     // Initialize CFACTOR, VAR, FIX.  Assign values to VAR and FIX
-    // which then point to C (or for F77, are EQUIVALENCEd to C).
+    // which then point to C (or for F77, which are EQUIVALENCEd to C).
     //
     Assign( Elm( X ), Mul( Elm( IV, varDefault ), Elm( CFACTOR ) ) );
     C_Inline("  for( i = 0; i < NVAR; i++ )" );

--- a/src/gen.c
+++ b/src/gen.c
@@ -75,6 +75,7 @@ int ATOL, RTOL, STEPMIN, STEPMAX, CFACTOR;
 int V_USER, CL;
 int NMLCV, NMLCF, SCT, PROPENSITY, VOLUME, IRCT;
 int FAM,NFAM;
+int NON_PASV_SPC_CT, NON_PASV_SPC_IND;
 
 int Jac_NZ, LU_Jac_NZ, nzr;
 
@@ -147,12 +148,11 @@ int i,j;
 
   /* PI      = DefConst( "PI",     real, "Value of pi" ); */
 
-//============================================================================
-// MODIFICATION by Bob Yantosca (25 Apr 2022)
-//
-// For Fortran-90, declare VAR and FIX as POINTER variables, which will
-// allow us to remove the non-threadsafe EQUIVALENCE statements.
-//
+  //
+  // For Fortran-90, declare VAR and FIX as POINTER variables, which will
+  // allow us to remove the non-threadsafe EQUIVALENCE statements.
+  //  -- Bob Yantosca (25 Apr 2022)
+  //
   if ( useLang == F90_LANG ) {
     VAR = DefvElmP( "VAR", real,
                     "Concentrations of variable species (global)" );
@@ -163,8 +163,8 @@ int i,j;
                    "Concentrations of variable species (global)" );
     FIX = DefvElm( "FIX", real, -NFIX,
                    "Concentrations of fixed species (global)" );
-}
-//============================================================================
+  }
+
   V = DefvElm( "V", real, -NVAR, "Concentrations of variable species (local)" );
   F = DefvElm( "F", real, -NFIX, "Concentrations of fixed species (local)" );
 
@@ -245,18 +245,18 @@ int i,j;
   IV = DefeElm( "IV", 0 );
 
   C_DEFAULT = DefvElm( "C_DEFAULT", real, -NSPEC, "Default concentration for all species" );
-//============================================================================
-// MODIFICATION by Bob Yantosca (25 Apr 2002)
-// For Fortran-90, declare C with the TARGET attribute.  This will allow
-// VAR and FIX to point to C, which will let us remove the non-threadsafe
-// EQUIVALENCE statements.
-//
+  //
+  // For Fortran-90, declare C with the TARGET attribute.  This will allow
+  // VAR and FIX to point to C, which will let us remove the non-threadsafe
+  // EQUIVALENCE statements.
+  //  -- Bob Yantosca (25 Apr 2022)
+  //
   if ( useLang == F90_LANG ) {
     C = DefvElmT( "C", real, -NSPEC, "Concentration of all species" );
   } else {
     C = DefvElm( "C", real, -NSPEC, "Concentration of all species" );
   }
-//============================================================================
+
   CL = DefvElm( "CL", real, -NSPEC, "Concentration of all species (local)" );
   ATOL = DefvElm( "ATOL", real, -NVAR, "Absolute tolerance" );
   RTOL = DefvElm( "RTOL", real, -NVAR, "Relative tolerance" );
@@ -279,8 +279,23 @@ int i,j;
   FAM_NAMES  = DefvElm( "FAM_NAMES", STRING, -NFAM, "Names of chemical familes" );
 
   CFACTOR  = DefElm( "CFACTOR", real, "Conversion factor for concentration units");
-
-  /* Autoreduction structures */
+  //
+  // Define variables that will allow us to exclude "passive" species (those
+  // added to reactions for diagnostic purposes), for Fortran90 only.
+  //   -- Bob Yantosca (02 Jul 2026)
+  //
+  if ( useLang == F90_LANG ) {
+    NON_PASV_SPC_CT = DefElm( "NonPassiveSpc_Count", INT,
+			      "Number of non-passive species in mechanism" );
+    NON_PASV_SPC_IND = DefvElm( "NonPassiveSpc_Indices", INT, -NVAR,
+				"Indices of non-passive species in mechanism" );
+  } else {
+    NON_PASV_SPC_CT = 0;
+    NON_PASV_SPC_IND = 0;
+  }
+  //
+  // Autoreduction structures
+  //
   NVARP1        = DefConst( "NVAR+1",  INT, "Number of Variable species + 1" );
   DO_JVS        = DefvElm("DO_JVS", LOGICAL, -LU_NONZERO, "");
   DO_SLV        = DefvElm("DO_SLV", LOGICAL, -NVARP1    , "");
@@ -300,8 +315,9 @@ int i,j;
 
   Aout = DefvElmO( "Aout", real, -NREACT,
                    "Optional argument to return equation rate constants" );
-
-  /* Elements of Stochastic simulation*/
+  //
+  // Elements of Stochastic simulation
+  //
   NMLCV = DefvElm( "NmlcV", INT, -NVAR, "No. molecules of variable species" );
   NMLCF = DefvElm( "NmlcF", INT, -NFIX, "No. molecules of fixed species" );
   SCT   = DefvElm( "SCT",  real, -NREACT, "Stochastic rate constants" );
@@ -312,8 +328,9 @@ int i,j;
   for ( i=0; i<EqnNr; i++ )
     for ( j=0; j<SpcNr; j++ )
       structB[i][j] = ( Stoich_Left[j][i] != 0 ) ? 1 : 0;
-
-  /* Constant values are useful to declare vectors of this size */
+  //
+  // Constant values are useful to declare vectors of this size
+  //
   if (useDeclareValues) {
     varTable[ NSPEC ]   -> value  = max(SpcNr,1);
     varTable[ NVAR  ]   -> value  = max(VarNr,1);
@@ -648,13 +665,14 @@ int F_VAR, FSPLIT_VAR;
 
   if (useLang != MATLAB_LANG)  /* Matlab generates an additional file per function */
        UseFile( functionFile );
-
+  //
   // Note: When changing the FunctionBegin declarations below,
   // the number of arguments minus one must be changed in DefFnc here
   // as well. (hplin, 7/6/22)
   // 
   // For F90, add an extra argument to Fun and Fun_Split to return
   // the Aout array. (hplin, bmy, 30 Apr 2024)
+  //
   if (useLang == F90_LANG) {
     F_VAR = DefFnc("Fun", 5,
 		   "time derivatives of variables - Aggregate form");
@@ -666,7 +684,7 @@ int F_VAR, FSPLIT_VAR;
     FSPLIT_VAR = DefFnc("Fun_SPLIT", 6,
                         "time derivatives of variables - Split form");
   }
-
+  //
   // We have added the capability to return equation rates and the
   // time derivative of variable species from Fun via optional arguments
   // Aout and VdotOut (when z_useAggregate=1)
@@ -675,6 +693,7 @@ int F_VAR, FSPLIT_VAR;
   // Vdotout functionality can be accomplished using Vdot (hplin, 7/6/22)
   //
   // F90 needs Fun to have an extra argument for Aout (hplin, bmy, 30 Apr 2024)
+  //
   if( z_useAggregate ) {
     if (useLang == F90_LANG) {
       FunctionBegin( F_VAR, V, F, RCT, Vdot, Aout );\
@@ -733,9 +752,10 @@ int F_VAR, FSPLIT_VAR;
       Assign( Elm( A, j ), prod );
     }
   }
-
+  //
   // Add code to return equation rates via optional argument Aout
   //   -- Bob Yantosca (29 Apr 2022)
+  //
   NewLines(1);
   if ( useLang == F90_LANG ) {
     fprintf(functionFile, "  !### Use Aout to return equation rates\n");
@@ -789,8 +809,9 @@ int F_VAR, FSPLIT_VAR;
       if( doAutoReduce ) F90_Inline("IF (DO_FUN(%d)) &",i+1);
       Assign( Elm( D_VAR, i ), sum );
     }
-
+    //
     // Add code to calculate Vdot also for split function:
+    //
     NewLines(1);
     if ( useLang == F90_LANG ) {
       // For F90, we can do operations on arrays:
@@ -813,8 +834,11 @@ int F_VAR, FSPLIT_VAR;
 
   FreeVariable( F_VAR );
   FreeVariable( FSPLIT_VAR );
-
-  /** hplin 4/10/22 add FUN_Split2 which overrides DO_FUN. only used for 1st order-autoreduce **/
+  //
+  // hplin 4/10/22
+  // add FUN_Split2 which overrides DO_FUN.
+  // only used for 1st order-autoreduce
+  //
   if(!z_useAggregate && doAutoReduce) {
     /* add a copy of FSPLIT that does not react to DO_FUN() */
     fprintf(functionFile, "! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n");
@@ -2341,21 +2365,23 @@ int YIN, Y;
 
   if (useLang==F90_LANG) {
     //
-    // SPECIAL HANDLING FOR F90:
-    // -------------------------
-    // Manually write the "SUBROUTINE RCONST ( YIN )" line instead of
-    // using the FunctionBegin( UPDATE_RCONST ).  This will allow us
-    // to add any inlined F90 use statements immediately afterwards.
-    // Recall that F90 "USE" statements must precede variable
-    // declarations or any other executable statements, or else a
-    // compilation error will be generated.
+    // SPECIAL HANDLING FOR FORTRAN-90
+    // -------------------------------
+    // Use FunctionBeginNoArgDecl to create the subroutine interface.
+    // Then manually declare subroutine arguments after inlining USE
+    // statements from the F90_RCONST_USE section.  This will avoid
+    // compile-time errors caused by variable declarations preceding
+    // USE statements.
+    //    -- Bob Yantosca (02 Jul 2026)
     //
-    //    -- Bob Yantosca (19 Dec 2024)
+    UPDATE_RCONST = DefFnc( "Update_RCONST", 1,
+			    "function to update rate constants");
+    YIN = DefvElmO( "YIN", real, -NVAR,
+		    "Optional input concentrations of variable species" );
+    FunctionBeginNoArgDecl( UPDATE_RCONST, YIN );
     //
-    bprintf("SUBROUTINE Update_RCONST ( YIN )");
-    NewLines(2);
-
-    // Inline USE statements right after the subroutine declaration
+    // Inline USE statements immediately following the subroutine interface
+    //
     WriteComment("Begin inlined code from F90_RCONST_USE");
     NewLines(1);
     bprintf( InlineCode[ F90_RCONST_USE ].code );
@@ -2363,35 +2389,39 @@ int YIN, Y;
     NewLines(1);
     WriteComment("End inlined code from F90_RCONST_USE");
     NewLines(1);
-
-    // Declare optional YIN argument
-    YIN = DefvElmO( "YIN", real, -NVAR, "Optional input concentrations of variable species" );
+    //
+    // Declare optional YIN argument after USE statements are inlined
+    //
     Declare(YIN);
     NewLines(1);
-
+    //
     // Declare local Y variable
+    //
     Y = DefvElm( "Y", real, -NSPEC, "Concentrations of species (local)" );
     Declare(Y);
     NewLines(1);
-
+    //
     // Copy values of YIN to Y if YIN is present
+    //
     WriteComment("Ensure local Y array is filled with variable and constant concentrations");
-    bprintf("  Y(1:NSPEC) = C(1:NSPEC)\n");
+    F90_Inline("  Y(1:NSPEC) = C(1:NSPEC)");
     NewLines(1);
     WriteComment("Update local Y array if variable concentrations are provided");
-    bprintf("  if (present(YIN)) Y(1:NVAR) = YIN(1:NVAR)\n");
+    F90_Inline("  if (present(YIN)) Y(1:NVAR) = YIN(1:NVAR)\n");
     NewLines(1);
-
-    // Zero the UPDATE_RCONST to avoid compiler warnings
-    UPDATE_RCONST = 0;
   } else {
     //
-    // For other languages, declare function w/o any arguments
+    // C, FORTRAN-77, MATLAB
+    // ---------------------
+    // Declare UPDATE_RCONST function without any arguments
     //
-    UPDATE_RCONST = DefFnc( "Update_RCONST", 0, "function to update rate constants");
+    UPDATE_RCONST = DefFnc( "Update_RCONST", 0,
+			    "function to update rate constants");
     FunctionBegin( UPDATE_RCONST );
- }
-
+  }
+  //
+  // Inline F77 and MATLAB include files
+  //
   F77_Inline("      INCLUDE '%s_Global.h'", rootFileName);
   MATLAB_Inline("global SUN TEMP RCONST");
 
@@ -2399,28 +2429,31 @@ int YIN, Y;
       IncludeCode( "%s/util/UserRateLaws_FcnHeader", Home );
 
   NewLines(1);
-
+  //
   // Inline code from {C,F77,F90_MATLAB}_RCONST inline keys
+  //
   NewLines(1);
   WriteComment("Begin inlined code from F90_RCONST");
   NewLines(1);
 
   switch( useLang ) {
-    case C_LANG:  bprintf( InlineCode[ C_RCONST ].code );
-                 break;
-    case F77_LANG: bprintf( InlineCode[ F77_RCONST ].code );
-                 break;
-    case F90_LANG: bprintf( InlineCode[ F90_RCONST ].code );
-                 break;
+    case C_LANG:      bprintf( InlineCode[ C_RCONST ].code );
+                      break;
+    case F77_LANG:    bprintf( InlineCode[ F77_RCONST ].code );
+                      break;
+    case F90_LANG:    bprintf( InlineCode[ F90_RCONST ].code );
+                      break;
     case MATLAB_LANG: bprintf( InlineCode[ MATLAB_RCONST ].code );
-                 break;
+                      break;
   }
   FlushBuf();
 
   NewLines(1);
   WriteComment("End inlined code from F90_RCONST");
   NewLines(1);
-
+  //
+  // Inline the reaction rate coefficients
+  //
   for( i = 0; i < EqnNr; i++) {
     /*  mz_rs_20220701+ */
     if (useEqntags==1) {
@@ -2440,21 +2473,11 @@ int YIN, Y;
 
   MATLAB_Inline("   RCONST = RCONST(:);");
   //
-  // SPECIAL HANDLING FOR F90:
-  // -------------------------
-  // Manually write the "END SUBROUTINE UPDATE_RCONST" line when
-  // generating F90 output.  But if generating C, F77, MatLab output,
-  // then close the UPDATE_RCONST routine as we normally would.
-  //   -- Bob Yantosca (19 Dec 2024)
+  // Cleanup
   //
-  if (useLang == F90_LANG) {
-    NewLines(1);
-    bprintf("END SUBROUTINE UPDATE_RCONST");
-    NewLines(1);
-  } else {
-    FunctionEnd( UPDATE_RCONST );
-    FreeVariable( UPDATE_RCONST );
-  }
+  FunctionEnd( UPDATE_RCONST );
+  FreeVariable( UPDATE_RCONST );
+  FreeVariable( YIN );
 }
 
 
@@ -2476,6 +2499,7 @@ int UPDATE_PHOTO;
     // SPECIAL HANDLING FOR F90:
     // -------------------------
     // Inline USE statements right after the subroutine declaration
+    //
     WriteComment("Begin inlined code from F90_RCONST_USE");
     NewLines(1);
     bprintf( InlineCode[ F90_RCONST_USE ].code );
@@ -2709,25 +2733,24 @@ int j,dummy_species;
 void GenerateGlobalHeader()
 {
   int useFortran;
-
-//===========================================================================
-// MODIFICATION: Bob Yantosca (26 Mar 2021)
-//
-// Modify code to inline the F77/F90 THREADPRIVATE declarations, and also
-// declare extra arrays and scalars.  These declarations begin with a
-// comment character and will be ignored unless the Fortran-90 code is
-// compiled with OpenMP.
-//===========================================================================
-
-  /*** Define a flag to denote if we are using F90 or F77 ***/
+  //
+  // Modify code to inline the F77/F90 THREADPRIVATE declarations, and also
+  // declare extra arrays and scalars.  These declarations begin with a
+  // comment character and will be ignored unless the Fortran-90 code is
+  // compiled with OpenMP.
+  //  -- Bob Yantosca (26 Mar 2021)
+  //
+  // Define a flag to denote if we are using Fortran (either F90 or F77)
+  //
   if ( useLang == F90_LANG || useLang == F77_LANG ) { useFortran = 1; }
   else                                              { useFortran = 0; }
 
   UseFile( global_dataFile );
 
   CommonName = "GDATA";
-
-  /*** Write comment header ***/
+  //
+  // Write comment header
+  //
   NewLines(1);
   WriteComment("Declaration of global variables");
   if ( useFortran ) {
@@ -2753,12 +2776,14 @@ void GenerateGlobalHeader()
       "~~~ with OpenMP parallelization turned on.");
   }
   NewLines(1);
-
-  /*** Declare C, concentration array ***/
+  //
+  // Declare C, concentration array
+  //
   ExternDeclare( C );
   if ( useFortran ) { WriteOMPThreadPrivate("C"); }
-
-  /*** Declare VAR and FIX for F90 (these are now pointers!) ***/
+  //
+  // Declare VAR and FIX for F90 (these are now pointers!)
+  //
   if ( useLang == F90_LANG ) {
     ExternDeclare( VAR );
     WriteOMPThreadPrivate("VAR");
@@ -2766,9 +2791,10 @@ void GenerateGlobalHeader()
     ExternDeclare( FIX );
     WriteOMPThreadPrivate("FIX");
   }
-
-  /*** Declare VAR and fix for F77                             ***/
-  /*** We need to keep the EQUIVALENCE statement for F77 only! ***/
+  //
+  // Declare VAR and fix for F77
+  // We need to keep the EQUIVALENCE statement for F77 only!
+  //
   if ( useLang == F77_LANG ) {
     Declare( VAR );
     WriteOMPThreadPrivate("VAR");
@@ -2783,20 +2809,23 @@ void GenerateGlobalHeader()
                  varTable[C]->name, VarNr+1, varTable[FIX]->name );
     }
   }
-
-  /*** Declare VAR and FIX for MatLab ***/
+  //
+  // Declare VAR and FIX for MatLab
+  //
   if ( useLang == MATLAB_LANG ) {
     ExternDeclare( VAR );
     ExternDeclare( FIX );
   }
-
-  /*** Declare VAR and FIX for C with the extern property ***/
+  //
+  // Declare VAR and FIX for C with the extern property
+  //
   if ( useLang == C_LANG ) {
     C_Inline("  extern %s * %s;", C_types[real], varTable[VAR]->name );
     C_Inline("  extern %s * %s;", C_types[real], varTable[FIX]->name );
   }
-
-  /*** Declare all other threadprivate variables ***/
+  //
+  // Declare all other threadprivate variables
+  //
   ExternDeclare( RCONST );
   if ( useFortran ) { WriteOMPThreadPrivate("RCONST"); }
 
@@ -2808,8 +2837,9 @@ void GenerateGlobalHeader()
 
   ExternDeclare( TEMP );
   if ( useFortran ) { WriteOMPThreadPrivate("TEMP"); }
-
-  /*** Declare non-threadprivate variables ***/
+  //
+  // Declare non-threadprivate variables
+  //
   NewLines(1);
   if ( useFortran ) {
     WriteComment(
@@ -2826,7 +2856,50 @@ void GenerateGlobalHeader()
   ExternDeclare( RTOL );
   ExternDeclare( STEPMIN );
   ExternDeclare( STEPMAX );
+  //
+  // Declare variables that can be used to exclude "passive" species
+  // from the Rosenbrock error norm and other computations (F90-only).
+  //   -- Bob Yantosca (02 Jul 2026)
+  //
+  if ( useLang == F90_LANG ) {
+    ExternDeclare( NON_PASV_SPC_CT );
+    ExternDeclare( NON_PASV_SPC_IND );
+  }
+  //
+  // Declare other variables
+  //
+  ExternDeclare( CFACTOR );
+  if (useStochastic)
+      ExternDeclare( VOLUME );
+
+  CommonName = "INTGDATA";
+  if ( useHessian ) {
+     ExternDeclare( DDMTYPE );
+  }
+
+  if ( (useLang == C_LANG) || (useLang == F77_LANG) ) {
+     CommonName = "INTGDATA";
+     ExternDeclare( LOOKAT );
+     ExternDeclare( MONITOR );
+     CommonName = "CHARGDATA";
+     ExternDeclare( SPC_NAMES );
+     ExternDeclare( SMASS );
+     ExternDeclare( EQN_NAMES );
+     ExternDeclare( EQN_TAGS );
+     ExternDeclare( FAM_NAMES );
+  }
+  //
+  // Special section for rosenbrock_autoreduce integrator variables (F90-only)
+  // Move this below the non-threadprivate variables.
+  //   -- Bob Yantosca (02 Jul 2026)
+  //
   if (doAutoReduce) {
+
+    NewLines(1);
+    WriteComment(
+     "~~~ Variables for the ""rosenbrock_autoreduce"" integrator");
+    NewLines(1);
+
     ExternDeclare(DO_JVS);
     ExternDeclare(DO_SLV);
     ExternDeclare(DO_FUN);
@@ -2846,28 +2919,9 @@ void GenerateGlobalHeader()
     WriteOMPThreadPrivate(" DO_JVS, DO_SLV, DO_FUN, cLU_IROW, cLU_ICOL, cLU_CROW");
     WriteOMPThreadPrivate(" cLU_DIAG, JVS_MAP, SPC_MAP, iSPC_MAP, RMV, rNVAR, cNONZERO, KEEPACTIVE "); /* msl_20160419 */
   }
-  ExternDeclare( CFACTOR );
-  if (useStochastic)
-      ExternDeclare( VOLUME );
-
-  CommonName = "INTGDATA";
-  if ( useHessian ) {
-     ExternDeclare( DDMTYPE );
-  }
-
-
-  if ( (useLang == C_LANG) || (useLang == F77_LANG) ) {
-     CommonName = "INTGDATA";
-     ExternDeclare( LOOKAT );
-     ExternDeclare( MONITOR );
-     CommonName = "CHARGDATA";
-     ExternDeclare( SPC_NAMES );
-     ExternDeclare( SMASS );
-     ExternDeclare( EQN_NAMES );
-     ExternDeclare( EQN_TAGS );
-     ExternDeclare( FAM_NAMES );
-  }
-
+  //
+  // Inline code from the F90_GLOBAL section here
+  //
   NewLines(1);
   WriteComment("Begin inlined code from F90_GLOBAL");
 
@@ -2882,7 +2936,9 @@ void GenerateGlobalHeader()
                  break;
   }
   FlushBuf();
-
+  //
+  // Cleanup
+  //
   NewLines(1);
   WriteComment("End inlined code from F90_GLOBAL");
   NewLines(1);
@@ -3106,40 +3162,84 @@ void GenerateInitialize()
 {
 int i;
 int I, X;
-int INITVAL;
+int INITVAL, PASV_SPC_ATOL_THRESH;
 
   if ( (useLang==C_LANG)||(useLang==F77_LANG)||(useLang==F90_LANG) )
       UseFile( initFile );
 
-  INITVAL    = DefFnc( "Initialize",    0, "function to initialize concentrations");
-  FunctionBegin( INITVAL );
+  if ( useLang == F90_LANG ) {
+    //
+    // SPECIAL HANDLING FOR FORTRAN-90
+    // -------------------------------
+    // Pass the optional "PassiveSpc_ATOL_Threshold" variable to the
+    // F90 Initialize routine.  This will allow the user to specify
+    // an absolute tolerance threshold that will be used to filter out
+    // "passive" species (i.e. species added to reactions for diagnostic
+    // purposes).
+    //
+    // Use FunctionBeginNoArgDecl to declare the subroutine interface.
+    // Then manually insert the subroutine argument declarations below
+    // all USE statements.  This will avoid compile-time errors caused
+    // by variable declarations preceding USE statements.
+    //   -- Bob Yantosca (02 Jul 2026)
+    //
+    INITVAL = DefFnc( "Initialize", 1,
+		      "function to initialize concentrations");
+    PASV_SPC_ATOL_THRESH = DefElmO( "PassiveSpc_ATOL_Threshold", real,
+			        "Species with ATOL > this value are passive");
+    FunctionBeginNoArgDecl( INITVAL, PASV_SPC_ATOL_THRESH );
+  } else {
+    //
+    // C, FORTRAN-77, MATLAB
+    // ---------------------
+    // Do not declare any subroutine arguments
+    //
+    INITVAL = DefFnc( "Initialize", 0,
+		      "function to initialize concentrations");
+    PASV_SPC_ATOL_THRESH = 0;
+    FunctionBegin( INITVAL );
+  }
+  //
+  // Inline include statements and/or USE statements
+  //
   F77_Inline("      INCLUDE '%s_Global.h'", rootFileName);
   F90_Inline("  USE %s_Global\n", rootFileName);
   MATLAB_Inline("global CFACTOR VAR FIX NVAR NFIX", rootFileName);
 
   F77_Inline("      INCLUDE '%s_Parameters.h'", rootFileName);
   F90_Inline("  USE %s_Parameters\n", rootFileName);
-
+  //
+  // Manually declare F90 function arguments after USE statements
+  // so as to avoid any compile-time errors.
+  //  -- Bob Yantosca (02 Jul 2026)
+  //
+  if ( useLang == F90_LANG ) {
+    Declare( PASV_SPC_ATOL_THRESH );
+    NewLines(1);
+  }
+  //
+  // Declare local variables
+  //
+  WriteComment("~~~ Local variables");
   I = DefElm( "i", INT, 0);
   X = DefElm( "x", real, 0);
   Declare( I );
   Declare( X );
-
+  //
+  // Assign CFACTOR
+  //
   NewLines(1);
   WriteComment("~~~ Define scale factor for units");
   WriteAssign( varTable[CFACTOR]->name , ascid( (double)cfactor ) );
   NewLines(1);
-
-  //=========================================================================
-  // MODIFICATION by Bob Yantosca (25 Apr 2022)
   //
   // For F90, assign values to C directly (since VAR and FIX now point to C
   // instead of the other way around).  Otherwise, preserve prior code.
-  //=========================================================================
+  //  -- Bob Yantosca (25 Apr 2022)
+  //
   if ( useLang == F90_LANG ) {
-
     //
-    // Fortran-90
+    // FORTRAN-90 only
     //
     WriteComment("~~~ Zero C array");
     if ( useDouble )
@@ -3157,11 +3257,43 @@ int INITVAL;
     }
 
     NewLines(1);
+    //
+    // Determine the count and index list of "non-passive" species,
+    // which have an absolute tolerance below a very high threshold.
+    // This will allow us to filter these dummy species out of
+    // e.g. Rosenbrock error norm calculations.  For F90-only.
+    //  -- Bob Yantosca (02 Jul 2026)
+    //
+    WriteComment(
+     "~~~ Determine the count and indices of actual species (as opposed to");
+    WriteComment(
+     "~~~ (""passive"" species used for diagnostics.  Denote passive species");
+    WriteComment(
+     "~~~ as those having ATOL > PassiveSpc_ATOL_Threshold.  If the optional");
+    WriteComment(
+     "~~~ argument PassiveSpc_ATOL_Threshold is not specified, then treat");
+    WriteComment(
+     "~~~ all variable species as non-passive species.");
+    F90_Inline("  NonPassiveSpc_Count   = 0");
+    F90_Inline("  NonPassiveSpc_Indices = 0");
+    F90_Inline("  IF ( PRESENT( PassiveSpc_ATOL_Threshold ) ) THEN");
+    F90_Inline("     DO I = 1, NVAR");
+    F90_Inline("        IF ( ATOL(I) < PassiveSpc_ATOL_Threshold ) THEN");
+    F90_Inline("           NonPassiveSpc_Count = NonPassiveSpc_Count + 1");
+    F90_Inline("           NonPassiveSpc_Indices(NonPassiveSpc_Count) = I");
+    F90_Inline("        ENDIF");
+    F90_Inline("     ENDDO");
+    F90_Inline("  ELSE");
+    F90_Inline("     NonPassiveSpc_Count = NVAR");
+    F90_Inline("     DO I = 1, NVAR");
+    F90_Inline("        NonPassiveSpc_Indices(I) = I");
+    F90_Inline("     ENDDO");
+    F90_Inline("  ENDIF");
+    NewLines(1);
 
   } else {
-
     //
-    // Fortran-77, C, and Matlab
+    // Initialize CFACTOR, VAR, FIX for C, FORTRAN-77, and MATLAB
     //
     Assign( Elm( X ), Mul( Elm( IV, varDefault ), Elm( CFACTOR ) ) );
     C_Inline("  for( i = 0; i < NVAR; i++ )" );
@@ -3200,14 +3332,18 @@ int INITVAL;
               Elm( CFACTOR ) ) );
     }
   }
-
+  //
+  // Inline constant rate coefficients here
+  //
   WriteComment("Begin constant rate coefficients");
   for( i = 0; i < EqnNr; i++) {
     if ( kr[i].type == NUMBER )
        Assign( Elm( RCONST, i ), Const( kr[i].val.f ) );
   }
   WriteComment("End constant rate coefficients");
-
+  //
+  // Inline code from C_INIT, F77_INIT, F90_INIT, MATLAB_INIT sections here
+  //
   NewLines(1);
   WriteComment("Begin inlined code from F90_INIT");
 
@@ -3228,7 +3364,9 @@ int INITVAL;
   NewLines(1);
 
   MATLAB_Inline("   VAR = VAR(:);\n   FIX = FIX(:);\n" );
-
+  //
+  // Cleanup
+  //
   FreeVariable( X );
   FreeVariable( I );
   FunctionEnd( INITVAL );

--- a/src/gen.c
+++ b/src/gen.c
@@ -3243,14 +3243,14 @@ int INITVAL, PASV_SPC_ATOL_THRESH;
   WriteComment("~~~ Define scale factor for units");
   WriteAssign( varTable[CFACTOR]->name , ascid( (double)cfactor ) );
   NewLines(1);
-  //
-  // For F90, assign values to C directly (since VAR and FIX now point to C
-  // instead of the other way around).  Otherwise, preserve prior code.
-  //  -- Bob Yantosca (25 Apr 2022)
-  //
+
   if ( useLang == F90_LANG ) {
     //
-    // FORTRAN-90 only
+    // FORTRAN-90
+    // -----------
+    // For F90, assign values to C directly (since VAR and FIX
+    // now point to C instead of the other way around).
+    //  -- Bob Yantosca (25 Apr 2022)
     //
     WriteComment("~~~ Zero C array");
     if ( useDouble )
@@ -3268,43 +3268,13 @@ int INITVAL, PASV_SPC_ATOL_THRESH;
     }
 
     NewLines(1);
-    //
-    // Determine the count and index list of "non-passive" species,
-    // which have an absolute tolerance below a very high threshold.
-    // This will allow us to filter these dummy species out of
-    // e.g. Rosenbrock error norm calculations.  For F90-only.
-    //  -- Bob Yantosca (02 Jul 2026)
-    //
-    WriteComment(
-     "~~~ Determine the count and indices of actual species (as opposed to");
-    WriteComment(
-     "~~~ (""passive"" species used for diagnostics.  Denote passive species");
-    WriteComment(
-     "~~~ as those having ATOL > PassiveSpc_ATOL_Threshold.  If the optional");
-    WriteComment(
-     "~~~ argument PassiveSpc_ATOL_Threshold is not specified, then treat");
-    WriteComment(
-     "~~~ all variable species as non-passive species.");
-    F90_Inline("  NonPassiveSpc_Count   = 0");
-    F90_Inline("  NonPassiveSpc_Indices = 0");
-    F90_Inline("  IF ( PRESENT( PassiveSpc_ATOL_Threshold ) ) THEN");
-    F90_Inline("     DO I = 1, NVAR");
-    F90_Inline("        IF ( ATOL(I) < PassiveSpc_ATOL_Threshold ) THEN");
-    F90_Inline("           NonPassiveSpc_Count = NonPassiveSpc_Count + 1");
-    F90_Inline("           NonPassiveSpc_Indices(NonPassiveSpc_Count) = I");
-    F90_Inline("        ENDIF");
-    F90_Inline("     ENDDO");
-    F90_Inline("  ELSE");
-    F90_Inline("     NonPassiveSpc_Count = NVAR");
-    F90_Inline("     DO I = 1, NVAR");
-    F90_Inline("        NonPassiveSpc_Indices(I) = I");
-    F90_Inline("     ENDDO");
-    F90_Inline("  ENDIF");
-    NewLines(1);
 
   } else {
     //
-    // Initialize CFACTOR, VAR, FIX for C, FORTRAN-77, and MATLAB
+    // C, FORTRAN-77, MATLAB
+    // ---------------------
+    // Initialize CFACTOR, VAR, FIX.  Assign values to VAR and FIX
+    // which then point to C (or for F77, are EQUIVALENCEd to C).
     //
     Assign( Elm( X ), Mul( Elm( IV, varDefault ), Elm( CFACTOR ) ) );
     C_Inline("  for( i = 0; i < NVAR; i++ )" );
@@ -3369,12 +3339,52 @@ int INITVAL, PASV_SPC_ATOL_THRESH;
                  break;
   }
   FlushBuf();
-
+ 
   NewLines(1);
   WriteComment("End inlined code from F90_INIT");
   NewLines(1);
 
   MATLAB_Inline("   VAR = VAR(:);\n   FIX = FIX(:);\n" );
+  //
+  if ( useLang == F90_LANG) {
+    //
+    // FORTRAN-90
+    // ----------
+    // Determine the count and index list of "non-passive" species, which
+    // have an absolute tolerance below a very high threshold.  This will
+    // allow us to filter these dummy species out of e.g. Rosenbrock error
+    // norm calculations.  Place this after the afer the F90_INIT block
+    // to avoid overwriting any inlined ATOL values.
+    //  -- Bob Yantosca (07 Jul 2026)
+    //
+    WriteComment(
+     "~~~ Determine the count and indices of actual species (as opposed to");
+    WriteComment(
+     "~~~ (""passive"" species used for diagnostics.  Denote passive species");
+    WriteComment(
+     "~~~ as those having ATOL > PassiveSpc_ATOL_Threshold.  If the optional");
+    WriteComment(
+     "~~~ argument PassiveSpc_ATOL_Threshold is not specified, then treat");
+    WriteComment(
+     "~~~ all variable species as non-passive species.");
+    F90_Inline("  NonPassiveSpc_Count   = 0");
+    F90_Inline("  NonPassiveSpc_Indices = 0");
+    F90_Inline("  IF ( PRESENT( PassiveSpc_ATOL_Threshold ) ) THEN");
+    F90_Inline("     DO I = 1, NVAR");
+    F90_Inline("        IF ( ATOL(I) < PassiveSpc_ATOL_Threshold ) THEN");
+    F90_Inline("           NonPassiveSpc_Count = NonPassiveSpc_Count + 1");
+    F90_Inline("           NonPassiveSpc_Indices(NonPassiveSpc_Count) = I");
+    F90_Inline("        ENDIF");
+    F90_Inline("     ENDDO");
+    F90_Inline("  ELSE");
+    F90_Inline("     NonPassiveSpc_Count = NVAR");
+    F90_Inline("     DO I = 1, NVAR");
+    F90_Inline("        NonPassiveSpc_Indices(I) = I");
+    F90_Inline("     ENDDO");
+    F90_Inline("  ENDIF");
+    NewLines(1);
+   
+  }
   //
   // Cleanup
   //
@@ -3382,6 +3392,9 @@ int INITVAL, PASV_SPC_ATOL_THRESH;
   FreeVariable( I );
   FunctionEnd( INITVAL );
   FreeVariable( INITVAL );
+  if ( useLang == F90_LANG ) {
+    FreeVariable( PASV_SPC_ATOL_THRESH );
+  }
 }
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/


### PR DESCRIPTION
### Overview

This is the companion PR to #66 and #144.  In this PR we create variables that can be used to exclude dummy species (i.e. those added to chemical reactions for the purpose of obtaining diagnostic information) from the Rosenbrock error norm computation.  This should prevent the issue where integration results are changed depending on the number of dummy species in the mechanism  (cf https://github.com/geoschem/geos-chem/issues/3175).

### Technical description

Two new module-level variables have been added to the `ROOT_Global` module (for F90 only).  These are:

1. `NonPassiveSpc_Count`: The number of non-passive species
2. `NonPassiveSpc_Indices`: The KPP species indices for non-passive species

These optional variables (which are stored in `ROOT_Global`) are constructed when the `Initialize` routine is called.  

- If `Initialize` is called with the `PassiveSpc_ATOL_Threshold` optional argument, then all species that have an absolute tolerance (`ATOL`) greater than or equal to `PassiveSpc_ATOL_Threshold` will be denoted as passive species.  In this case, `NonPassiveSpc_Count` will be equal to `NVAR` - the number of passive species and `NonPassiveSpc_Indices` will contain the index list of only the non-passive species.

- If `Initialize` is called without any optional arguments, then  `NonPassiveSpc_Count` will be equal to `NVAR` and `NonPassiveSpc_Indices` will contain the index list of all variable species.

We have also updated the algorithm in the `Ros_ErrorNorm` function (in each of the `int/rosenbrock*.f90 files)` to compute the error norm on the basis of non-passive species.   We have also optimized the function to facilitate vectorization and to remove unnecessary ELSE blocks, which can be a bottleneck:

```F90
!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  KPP_REAL FUNCTION ros_ErrorNorm ( Y, Ynew, Yerr, &
                               AbsTol, RelTol, VectorTol )
!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
!~~~> Computes the "scaled norm" of the error vector Yerr
!~~~>
!~~~> Now uses separate loops for scalar and vector tolerances,
!~~~> as this facilitates loop vectorization for better performance.
!~~~>
!~~~> Also uses NonPassiveSpc_Count and NonPassiveSpc_Indices (constructed
!~~~> in Initialize), so that we can exclude "passive" (e.g. prod/loss)
!~~~> species from the error norm computation.
!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   IMPLICIT NONE

! Input arguments
   KPP_REAL, INTENT(IN) :: Y(N), Ynew(N), Yerr(N), AbsTol(N), RelTol(N)
   LOGICAL, INTENT(IN) ::  VectorTol
! Local variables
   KPP_REAL :: Err, Scale, Ymax
   INTEGER  :: I, IDX

   Err = ZERO

   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   !~~~> Vector Tolerances (per-species AbsTol & RelTol)
   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   IF ( VectorTol ) THEN

      DO IDX = 1, NonPassiveSpc_Count
         I     = NonPassiveSpc_Indices(IDX)
         Ymax  = MAX( ABS( Y(I) ), ABS( Ynew(I) ) )
         Scale = AbsTol(I) + RelTol(I) * Ymax
         Err   = Err + ( Yerr(I) / Scale )**2
      ENDDO

      ! Normalize the error norm by the number of non-dummy species
      ! and prevent it from getting smaller than 1e-10
      Err           = SQRT( Err / NonPassiveSpc_Count )
      ros_ErrorNorm = MAX( Err, 1.0d-10 )
      RETURN

   ENDIF

   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   !~~~> Scalar Tolerance (same AbsTol & RelTol for all species)
   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   DO IDX = 1, NonPassiveSpc_Count
      I     = NonPassiveSpc_Indices(IDX)
      Ymax  = MAX( ABS( Y(I) ), ABS( Ynew(I) ) )
      Scale = AbsTol(1) + RelTol(1) * Ymax
      Err   = Err + ( Yerr(I) / Scale )**2
   ENDDO
   
   ! Normalize the error norm by the number of non-dummy species
   ! and prevent it from getting smaller than 1e-10
   Err           = SQRT( Err / NonPassiveSpc_Count )
   ros_ErrorNorm = MAX( Err, 1.0d-10 )

  END FUNCTION ros_ErrorNorm
```

### Other modifications bundled into this PR:
- Added C-I test `F90_ros_passivespc`, which adds 3 passive species to the `small_strato` mechanism.
- Added new driver program `drv/general_passivespc.f90`, which executes `CALL INITIALIZE( PassiveSpc_ATOL_Threshold = 1.0d25 )`.  This is used in the `F90_ros_passivespc` C-I test.
- Added KPP internal function `F90_FunctionBeginNoArgsDecl` (in `src/code_f90.c`).  This is similar to `F90_FunctionBegin`, except that it does not write any subroutine arguments.  This allows us to manually declare  subroutine below any F90 `USE` statements.
- Added macro `DefElmO` in `src/code.h`, which defines a scalar F90 variable with the `OPTIONAL` attribute.
- Added GNU 14, 15, 16 compilers to the "Run C-I tests" GitHub action.
- Set `Hacc = ZERO;` and `ErrOld = ZERO;` in `int/runge_kutta.c` to avoid generating compiler warnings during C-I tests
- Updated `ICNTRL` and `RCNTRL` comment headers in the `int/rosenbrock*.f90` integrator files.
- Updated ReadtheDocs documentation accordingly.

### Related GitHub issues
- Closes #66
- Closes #144
- See https://github.com/geoschem/geos-chem/issues/3175

Tagging @RolfSander @msl3v @jimmielin @obin1 @fsolmon @ujongebloed @mje1398